### PR TITLE
added toc to the landing page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,101 @@ If this is your first time learning about Dockstore, we recommend starting with 
 you to the core concepts of Dockstore, leaving you with a good understanding of the platform. However, if you are simply looking to launch tools and workflows, we recommend
 going straight to the :doc:`End User Topics <end-user-topics/end-user-topics>` or our `quickstart guide <https://dockstore.org/quick-start>`_.
 
+.. toctree::
+   :caption: About
+   :maxdepth: 1
+
+   dockstore-introduction
+
+.. toctree::
+   :caption: Getting Started Guide
+   :maxdepth: 1
+
+   getting-started/getting-started
+   getting-started/getting-started-with-docker
+   getting-started/getting-started-with-cwl
+   getting-started/getting-started-with-wdl
+   getting-started/getting-started-with-nextflow
+   getting-started/register-on-dockstore
+   getting-started/dockstore-tools
+   getting-started/dockstore-workflows
+   getting-started/hosted-tools-and-workflows
+   getting-started/getting-started-with-services
+
+.. toctree::
+   :caption: Launch
+   :maxdepth: 1
+
+   launch-with/launch
+   launch-with/cgc-launch-with
+   launch-with/dnanexus-launch-with
+   launch-with/dnastack-launch-with
+   launch-with/terra-launch-with
+
+.. toctree::
+   :caption: Advanced Developer Topics
+   :maxdepth: 1
+
+   advanced-topics/advanced-topics
+   advanced-topics/docker-registries
+   advanced-topics/ways-to-register-tools
+   advanced-topics/public-and-private-tools
+   advanced-topics/checker-workflows
+   advanced-topics/checker-workflow-trs
+   advanced-topics/sharing-workflows
+   advanced-topics/guid-alias
+   advanced-topics/set-up-file-provisioning-plugins
+   advanced-topics/developing-file-provisioning-plugins
+   advanced-topics/advanced-features
+   advanced-topics/conversions
+   advanced-topics/batch-services
+   advanced-topics/aws-batch
+   advanced-topics/azure-batch
+   advanced-topics/posting-zips
+   advanced-topics/verification
+   advanced-topics/organizations-and-collections
+   advanced-topics/best-practices/best-practices
+   advanced-topics/best-practices/wdl-best-practices
+   advanced-topics/best-practices/nfl-best-practices
+
+.. toctree::
+   :caption: End User Topics
+   :maxdepth: 1
+
+   end-user-topics/end-user-topics
+   end-user-topics/faceted-search
+   end-user-topics/starring
+   end-user-topics/language-support
+
+.. toctree::
+   :caption: Extras
+   :maxdepth: 1
+
+   user-created
+   posters-and-talks
+
+.. toctree::
+   :caption: FAQ
+   :maxdepth: 1
+
+   faq
+
+.. toctree::
+   :caption: Changelog
+   :maxdepth: 1
+
+   changelog
+
+.. toctree::
+   :caption: News and Events
+   :maxdepth: 1
+   :glob:
+   :titlesonly:
+   :reversed:
+
+   news
+   news/*
+
 .. centered:: In Affiliation with
 
 .. centered:: |CollabLink|_ |OicrLink|_ |Ga4ghLink|_ |UcscLink|_
@@ -58,105 +153,3 @@ going straight to the :doc:`End User Topics <end-user-topics/end-user-topics>` o
     :alt: dnastack
     :height: 65px
 .. _DnaStackLink: https://dnastack.com/
-
-.. toctree::
-   :hidden:
-
-   dockstore-introduction
-
-.. toctree::
-   :caption: Getting Started Guide
-   :maxdepth: 2
-   :hidden:
-
-   getting-started/getting-started
-   getting-started/getting-started-with-docker
-   getting-started/getting-started-with-cwl
-   getting-started/getting-started-with-wdl
-   getting-started/getting-started-with-nextflow
-   getting-started/register-on-dockstore
-   getting-started/dockstore-tools
-   getting-started/dockstore-workflows
-   getting-started/hosted-tools-and-workflows
-   getting-started/getting-started-with-services
-
-.. toctree::
-   :caption: Launch
-   :maxdepth: 2
-   :hidden:
-
-   launch-with/launch
-   launch-with/cgc-launch-with
-   launch-with/dnanexus-launch-with
-   launch-with/dnastack-launch-with
-   launch-with/terra-launch-with
-
-.. toctree::
-   :caption: Advanced Developer Topics
-   :maxdepth: 2
-   :hidden:
-
-   advanced-topics/advanced-topics
-   advanced-topics/docker-registries
-   advanced-topics/ways-to-register-tools
-   advanced-topics/public-and-private-tools
-   advanced-topics/checker-workflows
-   advanced-topics/checker-workflow-trs
-   advanced-topics/sharing-workflows
-   advanced-topics/guid-alias
-   advanced-topics/set-up-file-provisioning-plugins
-   advanced-topics/developing-file-provisioning-plugins
-   advanced-topics/advanced-features
-   advanced-topics/conversions
-   advanced-topics/batch-services
-   advanced-topics/aws-batch
-   advanced-topics/azure-batch
-   advanced-topics/posting-zips
-   advanced-topics/verification
-   advanced-topics/organizations-and-collections
-   advanced-topics/best-practices/best-practices
-   advanced-topics/best-practices/wdl-best-practices
-   advanced-topics/best-practices/nfl-best-practices
-
-.. toctree::
-   :caption: End User Topics
-   :maxdepth: 2
-   :hidden:
-
-   end-user-topics/end-user-topics
-   end-user-topics/faceted-search
-   end-user-topics/starring
-   end-user-topics/language-support
-
-.. toctree::
-   :caption: Extras
-   :maxdepth: 2
-   :hidden:
-
-   user-created
-   posters-and-talks
-
-.. toctree::
-   :caption: FAQ
-   :maxdepth: 2
-   :hidden:
-
-   faq
-
-.. toctree::
-   :caption: Changelog
-   :maxdepth: 2
-   :hidden:
-
-   changelog
-
-.. toctree::
-   :caption: News and Events
-   :maxdepth: 2
-   :hidden:
-   :glob:
-   :titlesonly:
-   :reversed:
-
-   news
-   news/*


### PR DESCRIPTION
https://github.com/dockstore/dockstore/issues/2901

The landing page of the docs now includes a high level listing of each section and the names of each page.