### PR TITLE
mentioned readme as a fallback to description

### DIFF
--- a/docs/getting-started/getting-started-with-cwl.rst
+++ b/docs/getting-started/getting-started-with-cwl.rst
@@ -139,6 +139,12 @@ original tool. I'm biased towards the person that registers the tool
 since they are likely to be the primary contact when asking questions
 about how the tool was setup.
 
+Dockstore uses the authorship information and description from the
+descriptor file to populate metadata for tools.
+
+.. note:: If no description is defined in the descriptor file, the
+          README from the corresponding Git repository is used.
+
 You can register for an `ORCID <https://orcid.org/>`__ (a digital
 identifer for researchers) or use an email address for your id.
 

--- a/docs/getting-started/getting-started-with-nextflow.rst
+++ b/docs/getting-started/getting-started-with-nextflow.rst
@@ -57,6 +57,9 @@ this case we have a description of the tool and the author name. Note
 that we use the author and description fields to populate metadata on
 Dockstore.
 
+.. note:: If no description is defined in the descriptor file, the
+          README from the corresponding Git repository is used.
+
 ::
 
     manifest {

--- a/docs/getting-started/getting-started-with-wdl.rst
+++ b/docs/getting-started/getting-started-with-wdl.rst
@@ -161,6 +161,9 @@ description in markdown that requires newlines, specify the newlines
 with :raw-latex:`\n `or specify a blank line with
 :raw-latex:`\n`:raw-latex:`\n`.
 
+.. note:: If no description is defined in the descriptor file, the
+          README from the corresponding Git repository is used.
+
 Below we show an example metadata section and how it will display on
 your workflow's landing page:
 


### PR DESCRIPTION
https://github.com/dockstore/dockstore/issues/3115

README is now used as a fallback if no description is given in the primary descriptor.