### PR TITLE
Add GCS support

### DIFF
--- a/docs/_static/language-support.html
+++ b/docs/_static/language-support.html
@@ -105,12 +105,14 @@
             <td style="background-color:#dff0d8; padding: 5px;">Local File System
                 <br>HTTP
                 <br>FTP
+                <br>GCS via plugins
                 <br>S3 via plugins
                 <br><a href="https://github.com/ga4gh/data-object-service-schemas">Data Object Service</a>
             </td>
             <td style="background-color:#dff0d8; padding: 5px;">Local File System
                 <br>HTTP
                 <br>FTP
+                <br>GCS via plugins
                 <br>S3 via plugins
                 <br><a href="https://github.com/ga4gh/data-object-service-schemas">Data Object Service</a>
             </td>
@@ -123,6 +125,8 @@
         <tr style="border-top: 1px solid #ddd; ">
             <td style="padding: 5px;">Plugins Support</td>
             <td style="background-color:#dff0d8; padding: 5px;">
+                <a href="https://github.com/dockstore/gs-plugin">GCS</a>
+                <br>
                 <a href="https://github.com/dockstore/s3-plugin">s3</a>
                 <br>
                 <a href="https://github.com/dockstore/s3cmd-plugin">s3cmd</a>
@@ -132,6 +136,8 @@
                 <a href="https://github.com/dockstore/data-object-service-plugin">Data Object Service</a>
             </td>
             <td style="background-color:#dff0d8; padding: 5px;">
+                <a href="https://github.com/dockstore/gs-plugin">GCS</a>
+                <br>
                 <a href="https://github.com/dockstore/s3-plugin">s3</a>
                 <br>
                 <a href="https://github.com/dockstore/s3cmd-plugin">s3cmd</a>
@@ -147,6 +153,7 @@
             <td style="background-color:#dff0d8; padding: 5px;">Local File System
                 <br>HTTP
                 <br>FTP
+                <br>GCS via plugins
                 <br>S3 via plugins
             </td>
             <td style="background-color:#fcf8e3; padding: 5px;">Local File System


### PR DESCRIPTION
Add Google Cloud Storage to the list of storage systems supported in file provisioning 
Addresses https://ucsc-cgl.atlassian.net/browse/DOCK-1132