### PR TITLE
Add docs support for WDL output file provisioning

### DIFF
--- a/docs/_static/language-support.html
+++ b/docs/_static/language-support.html
@@ -158,7 +158,13 @@
                 <br>GCS via plugins
                 <br>S3 via plugins
             </td>
-            <td style="background-color:#fcf8e3; padding: 5px;">Local File System
+            <td style="background-color:#fcf8e3; padding: 5px;">
+                <sup>[7]</sup>
+                <br>Local File System
+                <br>HTTP
+                <br>FTP
+                <br>GCS via plugins
+                <br>S3 via plugins
             </td>
             <td style="background-color:#dff0d8; padding: 5px;">Local File System
                 <br><a href="https://www.nextflow.io/docs/latest/process.html#storedir">S3</a>

--- a/docs/advanced-topics/advanced-features.rst
+++ b/docs/advanced-topics/advanced-features.rst
@@ -9,7 +9,7 @@ provisioning for inputs and outputs.
 
 File provisioning for some protocols, like HTTP and FTP, is built-in
 while other protocols are handled by plugins as documented
-`here <https://github.com/dockstore/dockstore/tree/master/dockstore-file-plugin-parent>`__.
+`here <https://github.com/dockstore/dockstore-cli/tree/master/dockstore-file-plugin-parent>`__.
 
 To illustrate, for this
 `tool <https://dockstore.org/containers/quay.io/collaboratory/dockstore-tool-bamstats>`__

--- a/docs/advanced-topics/developing-file-provisioning-plugins.rst
+++ b/docs/advanced-topics/developing-file-provisioning-plugins.rst
@@ -27,12 +27,12 @@ The steps for implementing a new plugin are as follows:
 4. Rename the Java class to match the plugin class entered earlier in
    the pom.xml.
 5. Implement the downloadFrom and uploadTo methods from
-   `ProvisionInterface <https://github.com/dockstore/dockstore/blob/master/dockstore-file-plugin-parent/src/main/java/io/dockstore/provision/ProvisionInterface.java>`__
+   `ProvisionInterface <https://github.com/dockstore/dockstore-cli/blob/master/dockstore-file-plugin-parent/src/main/java/io/dockstore/provision/ProvisionInterface.java>`__
    Note that if your file provisioning system is input-only or
    output-only, you can throw an OperationNotSupportedException or
    similar.
 6. We recommend using
-   `ProgressPrinter <https://github.com/dockstore/dockstore/blob/master/dockstore-file-plugin-parent/src/main/java/io/dockstore/provision/ProgressPrinter.java>`__
+   `ProgressPrinter <https://github.com/dockstore/dockstore-cli/blob/master/dockstore-file-plugin-parent/src/main/java/io/dockstore/provision/ProgressPrinter.java>`__
    to give your users an indication of file upload/download progress.
 7. If applicable, for file transfer systems that include metadata or
    require preparation or finalize steps, you can override the default

--- a/docs/dockstore-introduction.rst
+++ b/docs/dockstore-introduction.rst
@@ -4,7 +4,7 @@ About Dockstore
 The Dockstore concept is simple, provide a place where users can share
 tools encapsulated in Docker and described with the `Common Workflow
 Language <https://www.commonwl.org/>`__ (CWL) or
-`Workflow Description Language <http://www.openwdl.org/>`__ (WDL),
+`Workflow Description Language <https://openwdl.org/>`__ (WDL),
 workflow languages used by members of and APIs created by the
 `GA4GH <https://www.ga4gh.org>`__ `Cloud Work
 Stream <http://ga4gh.cloud/>`__. This enables scientists, for example,

--- a/docs/end-user-topics/language-support.rst
+++ b/docs/end-user-topics/language-support.rst
@@ -38,6 +38,7 @@ Limitations`_ for limitations.
 
 .. _`AnVIL Limitations`: ../launch-with/anvil-launch-with.html#limitations
 
+[7] Use the Dockstore CLI optional parameter --wdl-output-target which allows you to specify a remote path to provision output files to ex: s3://oicr.temp/testing-launcher/
 
 
 Converting File-path Based Imports to Public http(s) Based Imports for WDL

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -13,7 +13,7 @@ FTP, and S3. We also have preliminary support for
 `Synapse <https://www.synapse.org/>`__ and the `ICGC Storage
 client <https://docs.icgc.org/download/guide/#score-client-usage>`__.
 Please see `file provisioning
-plugins <https://github.com/dockstore/dockstore/tree/master/dockstore-file-plugin-parent>`__
+plugins <https://github.com/dockstore/dockstore-cli/tree/master/dockstore-file-plugin-parent>`__
 for more information on these two file transfer sources.
 
 What environment do you test tools in?

--- a/docs/getting-started/getting-started-with-wdl.rst
+++ b/docs/getting-started/getting-started-with-wdl.rst
@@ -11,7 +11,7 @@ Tutorial Goals
 --------------
 
 -  Learn about the `Workflow Description Language
-   (WDL) <http://www.openwdl.org/>`__
+   (WDL) <https://openwdl.org/>`__
 -  Create a basic WDL Tool which uses a Docker image
 -  Run the Tool locally
 -  Describe a sample parameterization of the Tool

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -146,7 +146,7 @@ going straight to the :doc:`End User Topics <end-user-topics/end-user-topics>` o
 .. |WdlLink| image:: /assets/images/affiliations/wdl.png
     :alt: wdl
     :height: 65px
-.. _WdlLink: http://www.openwdl.org/
+.. _WdlLink: https://openwdl.org/
 
 .. |NflLink| image:: /assets/images/affiliations/nfl.png
     :alt: nextflow

--- a/docs/launch-with/launch.rst
+++ b/docs/launch-with/launch.rst
@@ -13,7 +13,7 @@ The dockstore command-line includes basic tool and workflow launching
 capability built on top of
 `cwltool <https://github.com/common-workflow-language/cwltool>`__. The
 Dockstore command-line also includes support for file provisioning via
-`plugins <https://github.com/dockstore/dockstore/tree/master/dockstore-file-plugin-parent>`__
+`plugins <https://github.com/dockstore/dockstore-cli/tree/master/dockstore-file-plugin-parent>`__
 which allow for the reading of input files and the upload of output
 files from remote file systems. Support for HTTP and HTTPS is built-in.
 Support for AWS S3 and `ICGC Score

--- a/docs/news/2017-05-05-Upcoming-Features.rst
+++ b/docs/news/2017-05-05-Upcoming-Features.rst
@@ -50,7 +50,7 @@ Highlighted New Features
 -  Stargazers page to show all users who have starred a particular tool
    or workflow
 -  Support for `file provisioning
-   plugins <https://github.com/dockstore/dockstore/tree/master/dockstore-file-plugin-parent>`__
+   plugins <https://github.com/dockstore/dockstore-cli/tree/master/dockstore-file-plugin-parent>`__
 -  Better error messaging passed along from a newer cwltool version
 -  Compatibility with a Write API service for programmatically adding
    tools
@@ -70,4 +70,3 @@ Breaking Changes
 
 .. discourse::
     :topic_identifier: 2021
-    


### PR DESCRIPTION
File provisioning out is supported for Cromwell WDL if you use the Dockstore CLI optional parameter –wdl-output-target which allows you to specify a remote path to provision output files to ex: s3://oicr.temp/testing-launcher/