### PR TITLE
Feature/3484/explain workflow name

### DIFF
--- a/docs/getting-started/dockstore-workflows.rst
+++ b/docs/getting-started/dockstore-workflows.rst
@@ -167,7 +167,7 @@ removed from Dockstore.
 
 .. tip:: Since the workflows field is an array, this file supports multiple workflows on Dockstore stemming from
    the same repository on GitHub. This is useful if you store a lot of your workflows in the same GitHub
-   repository. This is achieved by setting a different value for the name field for each entry (corresponding to the workflow name).
+   repository. This is achieved by setting a different value for the name field for each entry (corresponding to the workflow name of the entry).
 
 .. important:: The GitHub user who first adds a workflow onto Dockstore must correspond to a user on Dockstore.
 

--- a/docs/getting-started/dockstore-workflows.rst
+++ b/docs/getting-started/dockstore-workflows.rst
@@ -66,6 +66,46 @@ is the legacy registration process which is less automated, and used for Bitbuck
    link the necessary third-party accounts. Once this is done you can register
    workflows from the My Workflows page.
 
+
+Naming Workflows on Dockstore
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note:: Workflow paths are unique, descriptive identifiers for a workflow.
+
+Each workflow on Dockstore has a unique identifier in the form of a path. This path is based on
+the Git repository that the workflow comes from. There are four components to a path, but only
+three are required. In most cases these three required components are all you need.
+
+First we will look at the required components. This is the Git registry, the organization, and
+the repository. They are joined together by forward slashes, which can be seen below:
+
+``Git Registry/Organization/Repository``
+
+Ex. If I had a GitHub repository called BAMstats that existed in the OICR organization, the path of
+the workflow created from that repository would be the following:
+
+``github.com/OICR/BAMstats``
+
+Why not simply use a number to identify the workflow? With a path like that shown above, users
+can quickly understand the purpose of a workflow along with where it came from.
+
+The final optional component for the workflow path is the workflow name. This is a user defined
+string that will be appended to the end of the required workflow path. It is useful in two situations
+
+1) The name of the repository doesn't represent the workflow, or
+2) The repository contains multiple workflows
+
+Using the previous example, we could set the workflow name to ``coverage``. Our path would now be:
+
+``github.com/OICR/BAMstats/coverage``
+
+If we set the workflow name, we must include it in our path when referencing the workflow.
+
+.. tip:: Quick register does not support workflow names. Please use an alternative registration
+   process if you would like to register a workflow with a workflow name.
+
+
+
 .. _Registration With GitHub Apps:
 
 Registration With GitHub Apps

--- a/docs/getting-started/dockstore-workflows.rst
+++ b/docs/getting-started/dockstore-workflows.rst
@@ -90,7 +90,7 @@ Why not simply use a number to identify the workflow? With a path like that show
 can quickly understand the purpose of a workflow along with where it came from.
 
 The final optional component for the workflow path is the workflow name. This is a user defined
-string that will be appended to the end of the required workflow path. It is useful in two situations
+string that will be appended to the end of the required workflow path. It is useful in two situations:
 
 1) The name of the repository doesn't represent the workflow, or
 2) The repository contains multiple workflows
@@ -167,7 +167,7 @@ removed from Dockstore.
 
 .. tip:: Since the workflows field is an array, this file supports multiple workflows on Dockstore stemming from
    the same repository on GitHub. This is useful if you store a lot of your workflows in the same GitHub
-   repository. This is achieved setting a different value for the name field for (Corresponds to the workflow name).
+   repository. This is achieved by setting a different value for the name field for each entry (corresponding to the workflow name).
 
 .. important:: The GitHub user who first adds a workflow onto Dockstore must correspond to a user on Dockstore.
 

--- a/docs/getting-started/dockstore-workflows.rst
+++ b/docs/getting-started/dockstore-workflows.rst
@@ -167,9 +167,9 @@ removed from Dockstore.
 
 .. tip:: Since the workflows field is an array, this file supports multiple workflows on Dockstore stemming from
    the same repository on GitHub. This is useful if you store a lot of your workflows in the same GitHub
-   repository. This is achieved setting a different value for the name field for each entry.
+   repository. This is achieved setting a different value for the name field for (Corresponds to the workflow name).
 
-.. note:: The GitHub user who first adds a workflow onto Dockstore must correspond to a user on Dockstore.
+.. important:: The GitHub user who first adds a workflow onto Dockstore must correspond to a user on Dockstore.
 
 .. seealso::
     - :doc:`Automatic Syncing with GitHub Apps and .dockstore.yml <github-apps/github-apps/>` - details on writing a .dockstore.yml file

--- a/docs/getting-started/github-apps/github-apps-troubleshooting-tips.rst
+++ b/docs/getting-started/github-apps/github-apps-troubleshooting-tips.rst
@@ -96,7 +96,7 @@ Why was a new workflow registered instead of migrating my existing one?
     Todo: Add information of how to delete
 
 During the original registration for your workflow, you may have filled out the ``Workflow Name`` field shown in the picture below.
-A new separate workflow can be registered if the original ``Workflow Name`` isn't included or doesn't match the ``name`` field in your ``/.dockstore.yml``.
+A new separate workflow will be registered if the original ``Workflow Name`` isn't included or doesn't match the ``name`` field in your ``/.dockstore.yml``.
 
 .. figure:: /assets/images/docs/workflow-name-field.png
    :alt: Workflow to Migrate


### PR DESCRIPTION
https://github.com/dockstore/dockstore/issues/3484

Better explain workflow name in our initial Workflow Registration tutorial. Existing GitHub apps docs did a great job of explaining workflow names, so I mostly left those untouched.

I've attached a screenshot of the main changes since I don't want to create a new branch on RTD (might forget to delete). This is on the Workflow Registration tutorial and is the first section in "Register Your Workflow in Dockstore".
![Screen Shot 2020-08-10 at 3 59 00 PM](https://user-images.githubusercontent.com/6331159/89825457-9d246300-db22-11ea-99be-f52f21eebebd.png)
