### PR TITLE
CLI checksum validation documentation 

### DIFF
--- a/docs/advanced-topics/checksum-support.rst
+++ b/docs/advanced-topics/checksum-support.rst
@@ -19,6 +19,21 @@ More specifically, the endpoints that contain checksums for files are as follows
 
 The id parameter used in the endpoints above can be found on an entry's public page; underneath the Info tab, look for the bolded words **TRS**.
 
+CLI Descriptor Validation Support
+------------------------------------------
+By default, when launching tools or workflows from the CLI, primary and secondary descriptors will be validated using their SHA-1 checksums. Checksums are
+not validated when launching local entries.
+
+You can prevent checksum validation with the ``--ignore-checksums`` flag. For example, the following command will not validate descriptor
+checksums:
+
+::
+
+    dockstore [tool/workflow] launch --ignore-checksums --entry <entryPath> --json <parameterFile>
+
+Note that if there are no remote checksums stored for a descriptor (i.e. the entry has not been refreshed since the addition of checksum support in Dockstore 1.9),
+this will not be considered a fatal checksum mismatch, and the launch command will continue to execute.
+
 Docker Image Checksum Support
 =============================
 Checksum support for Docker images is more nuanced than it is for files. For quick reference, the table below displays the languages and


### PR DESCRIPTION
Documentation for checksum validation implemented [here](https://github.com/dockstore/dockstore-cli/pull/45).