### PR TITLE
Fixed local links so that linkcheck no longer throws a errors

### DIFF
--- a/docs/advanced-topics/advanced-features.rst
+++ b/docs/advanced-topics/advanced-features.rst
@@ -1,6 +1,8 @@
 Advanced CLI Features
 =====================
 
+.. _file-provisioning:
+
 File Provisioning
 -----------------
 
@@ -241,6 +243,7 @@ provide the ``-t`` and ``--options`` options to the Cromwell command line.
     cromwell-extra-parameters: -t WDL, --options workflow_options.json
 
 
+.. _alternative-cwl-launchers:
 
 Alternative CWL Launchers
 -------------------------
@@ -278,6 +281,8 @@ following to your ``~/.dockstore/config``:
 ::
 
     cwlrunner: cwl-runner
+
+.. _cromwell-beta:
 
 Cromwell (Beta)
 ~~~~~~~~~~~~~~~
@@ -339,6 +344,7 @@ then test using
     also be used to specify the version of Cromwell used to launch CWL tools
     and workflows if you set ``cwlrunner: cromwell``.
 
+.. _notifications:
 
 Notifications
 -------------
@@ -395,6 +401,8 @@ Notes
    <!--stackedit_data:
    eyJoaXN0b3J5IjpbMjA4MjI5MzQ4NV19
    -->
+
+.. _workflow-execution-service-wes-command-line-interface-cli:
 
 Workflow Execution Service (WES) Command Line Interface (CLI)
 -------------------------------------------------------------

--- a/docs/advanced-topics/aws-batch.rst
+++ b/docs/advanced-topics/aws-batch.rst
@@ -23,8 +23,8 @@ decompose the underlying command-line invocation for the tool and use
 that as the command for your jobs, gaining a bit of performance. This
 tutorial focuses on using cwltool and using the Dockstore command-line
 to provide an experience that is more akin to running Dockstore or
-cwltool `on the
-command-line <../end-user-topics/launch.html#dockstore-cli>`__ out of
+cwltool :ref:`on the
+command-line <launch-dockstore-cli>` out of
 the box.
 
 1. Unfortunately, you will need to do the most difficult step first. You

--- a/docs/advanced-topics/azure-batch.rst
+++ b/docs/advanced-topics/azure-batch.rst
@@ -20,8 +20,8 @@ decompose the underlying command-line invocation for the tool and use
 that as the command for your jobs, gaining a bit of performance. This
 tutorial focuses on using cwltool and using the Dockstore command-line
 to provide an experience that is more akin to running Dockstore or
-cwltool `on the
-command-line <launch.html#dockstore-cli>`__ out of
+cwltool :ref:`on the
+command-line <launch-dockstore-cli>` out of
 the box.
 
 1. Run through Azure Shipyard's `Linux Installation

--- a/docs/advanced-topics/batch-services.rst
+++ b/docs/advanced-topics/batch-services.rst
@@ -14,7 +14,7 @@ AWS Batch
 ---------
 
 `AWS Batch <https://aws.amazon.com/batch/>`__ is built by Amazon Web
-Services. Look `here <aws-batch>`__ for a tutorial on how to run a few
+Services. Look :doc:`here <aws-batch>` for a tutorial on how to run a few
 sample tools via AWS.
 
 Azure Batch
@@ -23,7 +23,7 @@ Azure Batch
 `Azure Batch <https://azure.microsoft.com/en-us/services/batch/>`__ and
 the associated
 `batch-shipyard <https://github.com/Azure/batch-shipyard>`__ is built by
-Microsoft. Look `here <azure-batch>`__ for a tutorial on how to run a
+Microsoft. Look :doc:`here <azure-batch>` for a tutorial on how to run a
 few sample tools via Azure.
 
 Google Pipelines

--- a/docs/advanced-topics/checker-workflow-trs.rst
+++ b/docs/advanced-topics/checker-workflow-trs.rst
@@ -8,7 +8,7 @@ The Swagger UI for the TRS endpoints can be found
 `here <https://dockstore.org/api/static/swagger-ui/index.html#/GA4GH>`__.
 
 For this section we will reference the tool and checker workflow
-mentioned in the `Checker workflows <checker-workflows/>`__ tutorial.
+mentioned in the :doc:`Checker workflows <checker-workflows>` tutorial.
 
 Distinguishing Between an Entry and a Checker Workflow
 ------------------------------------------------------

--- a/docs/advanced-topics/checker-workflows.rst
+++ b/docs/advanced-topics/checker-workflows.rst
@@ -281,8 +281,8 @@ maintaining the correct directory structure.
 For Advanced Users
 ------------------
 
-You can interact with checker workflows using TRS. See `Checker
-Workflows and the TRS <checker-workflow-trs/>`__ for more information.
+You can interact with checker workflows using TRS. See :doc:`Checker
+Workflows and the TRS <checker-workflow-trs>` for more information.
 
 .. discourse::
     :topic_identifier: 1277

--- a/docs/advanced-topics/conversions.rst
+++ b/docs/advanced-topics/conversions.rst
@@ -138,7 +138,7 @@ Quay.io tokens. If not, please return to the web service usage section
 to get that running first. It is advised to ensure that the Write API
 web service is functioning correctly before using the client.
 
--  `Dockstore token <../getting-started/register-on-dockstore/>`__
+-  :doc:`Dockstore token </getting-started/register-on-dockstore>`
 
 Follow the "Getting Started with Dockstore" tutorial to get a Dockstore
 token. Note this down, it will later be used in the Write API client
@@ -156,7 +156,7 @@ in the Write API client properties file.
 
 In order to publish to Dockstore, Quay.io must be linked to Dockstore.
 See
-`Dockstore <../getting-started/register-on-dockstore.html#linking-with-external-services>`__
+:ref:`Dockstore <linking-with-external-services>`
 on how to link your Quay.io account to Dockstore.
 
 -  Write API web service URL

--- a/docs/advanced-topics/posting-zips.rst
+++ b/docs/advanced-topics/posting-zips.rst
@@ -9,8 +9,8 @@ to post the contents of a ZIP file as a new hosted workflow version.
 This API makes it easier to programatically post workflow versions that
 have been tested and produced by a build process.
 
-This API works in conjunction with the `Hosted Tools and
-Workflows <../getting-started/hosted-tools-and-workflows.html>`__ Dockstore
+This API works in conjunction with the :doc:`Hosted Tools and
+Workflows </getting-started/hosted-tools-and-workflows>` Dockstore
 feature. The contents of the zip are stored directly on Dockstore.
 
 Use Cases

--- a/docs/advanced-topics/set-up-file-provisioning-plugins.rst
+++ b/docs/advanced-topics/set-up-file-provisioning-plugins.rst
@@ -54,10 +54,10 @@ Configuration for plugins can be added to your
     client = /media/large_volume/icgc-storage-client-1.0.23/bin/icgc-storage-client
 
 To try an example and learn more about file provisioning, check out this
-`tutorial <advanced-features.html#file-provisioning>`__.
+:ref:`tutorial <file-provisioning>`.
 
 If you would like to create your own plugins, follow along
-`here <developing-file-provisioning-plugins.html>`__.
+:doc:`here <developing-file-provisioning-plugins>`.
 
 .. discourse::
     :topic_identifier: 1838

--- a/docs/dockstore-introduction.rst
+++ b/docs/dockstore-introduction.rst
@@ -53,7 +53,7 @@ You can register your tools and workflows on Dockstore in three broad
 ways as depicted above.
 
 A) Following our
-   `tutorials <getting-started/getting-started.html>`__,
+   :doc:`tutorials <getting-started/getting-started>`,
    you can save your descriptors on GitHub, build your Docker image
    automatically on Quay.io, and have Dockstore reach out and index your
    tools

--- a/docs/end-user-topics/end-user-topics.rst
+++ b/docs/end-user-topics/end-user-topics.rst
@@ -5,7 +5,7 @@ This section is for topics geared towards users who will be launching
 workflows both locally and in the cloud.
 
 Note that not all features are available in all workflow languages. It
-can be worthwhile looking at `Language Support <language-support.html>`__ to
+can be worthwhile looking at :doc:`Language Support <language-support>` to
 see what features are available to you.
 
 .. discourse::

--- a/docs/end-user-topics/language-support.rst
+++ b/docs/end-user-topics/language-support.rst
@@ -17,29 +17,24 @@ on the Dockstore site and in the Dockstore command-line utility.
 
 [1] Available in both classic and WDL EPAM Pipeline Builder
 
-[2] Does not support http(s) based imports. See `CGC
-Limitations`_ for limitations.
+[2] Does not support http(s) based imports. See :ref:`CGC
+Limitations <cgc-limitations>` for limitations.
 
-.. _`CGC Limitations`: ../launch-with/cgc-launch-with.html#limitations
+[3] Does not support file-path based imports. See :ref:`Terra
+Limitations <terra-limitations>` for limitations.
 
-[3] Does not support file-path based imports. See `Terra
-Limitations`_ for limitations.
-
-.. _`Terra Limitations`: ../launch-with/terra-launch-with.html#limitations
-
-
-[4] Does not support file-path or http(s) based imports. See `DNAstack
-Limitations <../launch-with/dnastack-launch-with.html#limitations>`__ for limitations.
+[4] Does not support file-path or http(s) based imports. See :ref:`DNAstack
+Limitations <dnastack-limitations>` for limitations.
 
 [5] All verified Dockstore WDL tools/workflows were tested successfully. However, we anticipate that more testing is needed for WDL workflows that use language features not contained within that dataset.
 
-[6] Does not support file-path based imports. See `AnVIL
-Limitations`_ for limitations.
-
-.. _`AnVIL Limitations`: ../launch-with/anvil-launch-with.html#limitations
+[6] Does not support file-path based imports. See :ref:`AnVIL
+Limitations <anvil-limitations>` for limitations.
 
 [7] Use the Dockstore CLI optional parameter --wdl-output-target which allows you to specify a remote path to provision output files to ex: s3://oicr.temp/testing-launcher/
 
+
+.. _converting-file-path-based-imports-to-public-http-s-based-imports-for-wdl:
 
 Converting File-path Based Imports to Public http(s) Based Imports for WDL
 --------------------------------------------------------------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -160,6 +160,8 @@ Additionally:
       your container. Make sure your host running Docker has sufficient
       scratch space for processing your genomics data.
 
+.. _how-do-i-use-the-dockstore-cli-on-a-mac:
+
 How do I use the Dockstore CLI on a Mac?
 ----------------------------------------
 
@@ -187,8 +189,11 @@ can change what it allocates using the Docker for Mac GUI under
 
 * The default allocation can cause workflows or tools to fail without informing the user with a memory or resource related error message. If you find that your workflow or tool is behaving differently on a Mac compared to a similarly resourced Ubuntu environment, you can try increasing the resources allocated to Docker on the Mac to resolve the discrepancy.
 
+.. _what-is-a-verified-tool-or-workflow:
+
 What is a verified tool or workflow?
 ------------------------------------
+
 A verified tool/workflow means that at least one version has been verified to be successfully ran on a platform.
 
 See :doc:`/advanced-topics/verification` for full details on this feature.
@@ -245,8 +250,8 @@ feature currently does not exist because these registries do not allow
 the retrieval of organization information. Likewise, workflows
 registered with other source code repositories lack this feature.
 
-Finally, for participants of the `limited sharing
-beta <../advanced-topics/sharing-workflows/>`__, you can enter the email
+Finally, for participants of the :doc:`limited sharing
+beta </advanced-topics/sharing-workflows/>`, you can enter the email
 addresses of the users you wish to share with to give them permissions
 to your workflow. This is only available for hosted workflows and users
 with Google accounts linked to Terra.
@@ -273,7 +278,7 @@ What is the difference between logging in with GitHub or logging in with Google?
 The intent here is that you should be able to login with either login
 method and still conveniently get into the same Dockstore account. With
 login via Google, if you are a Terra user you will also have access to
-`sharing functionality <../advanced-topics/sharing-workflows/>`__.
+:doc:`sharing functionality </advanced-topics/sharing-workflows>`.
 
 Note that for simplicity, each of your GitHub or Google accounts can
 only be associated with one account at a time. You will need to link

--- a/docs/getting-started/getting-started.rst
+++ b/docs/getting-started/getting-started.rst
@@ -1,5 +1,5 @@
 .. hint::
-    Mac users, make note of this `FAQ <../faq.html#how-do-i-use-the-dockstore-cli-on-a-mac>`_ entry if you run into errors while going through the developer tutorials.
+    Mac users, make note of this :ref:`FAQ <how-do-i-use-the-dockstore-cli-on-a-mac>` entry if you run into errors while going through the developer tutorials.
 
 Introduction
 ==================

--- a/docs/getting-started/register-on-dockstore.rst
+++ b/docs/getting-started/register-on-dockstore.rst
@@ -52,6 +52,8 @@ For Google users, your initial username will include an @ symbol. We
 recommend you change your username to something that is not an email to
 avoid unwanted email.
 
+.. _linking-with-external-services:
+
 Linking With External Services
 ------------------------------
 

--- a/docs/launch-with/anvil-launch-with.rst
+++ b/docs/launch-with/anvil-launch-with.rst
@@ -38,6 +38,8 @@ runtime environment (docker, cpu, memory, and disks) to avoid using
 limiting defaults on AnVIL. See more
 `here <https://cromwell.readthedocs.io/en/stable/wf_options/Overview>`__.
 
+.. _anvil-limitations:
+
 Limitations
 -----------
 
@@ -45,8 +47,8 @@ Limitations
    Dockstore are currently not supported.
 2. AnVIL does not currently support file-path based imports. Importing a
    workflow with file-based imports will result in error. See the
-   `converting file-based imports
-   doc <../end-user-topics/language-support.html#converting-file-path-based-imports-to-public-http-s-based-imports-for-wdl>`__
+   :ref:`converting file-based imports
+   doc <converting-file-path-based-imports-to-public-http-s-based-imports-for-wdl>`
    for more info.
 3. Only the WDL language is supported.
 

--- a/docs/launch-with/cgc-launch-with.rst
+++ b/docs/launch-with/cgc-launch-with.rst
@@ -31,6 +31,7 @@ must already exist.
 Then hit the "Import" button and continue from within the CGC
 interface to configure and run your workflow.
 
+.. _cgc-limitations:
 
 Limitations
 -----------

--- a/docs/launch-with/dnastack-launch-with.rst
+++ b/docs/launch-with/dnastack-launch-with.rst
@@ -83,6 +83,8 @@ specifies a runtime environment (docker, cpu, memory, and disks) if you
 have trouble importing the workflow and that the workflow has not been
 imported before.
 
+.. _dnastack-limitations:
+
 Limitations
 -----------
 

--- a/docs/launch-with/launch.rst
+++ b/docs/launch-with/launch.rst
@@ -6,6 +6,8 @@ Tutorial Goals
 
 -  Launch a tool and a workflow using the Dockstore CLI
 
+.. _launch-dockstore-cli:
+
 Dockstore CLI
 -------------
 
@@ -91,8 +93,8 @@ that currently support and are validated with CWL at
 https://ci.commonwl.org and for WDL,
 `Cromwell <https://github.com/broadinstitute/cromwell>`__.
 
-For developers, you may also wish to look at our brief summary at `batch
-services <../advanced-topics/batch-services.html>`__ and commercial solutions such as `DataBiosphere
+For developers, you may also wish to look at our brief summary at :doc:`batch
+services </advanced-topics/batch-services>` and commercial solutions such as `DataBiosphere
 dsub <https://github.com/DataBiosphere/dsub>`__ and
 `AWS Batch <https://aws.amazon.com/batch/>`__.
 

--- a/docs/launch-with/terra-launch-with.rst
+++ b/docs/launch-with/terra-launch-with.rst
@@ -36,6 +36,8 @@ runtime environment (docker, cpu, memory, and disks) to avoid using
 limiting defaults on Terra. See more
 `here <https://cromwell.readthedocs.io/en/stable/wf_options/Overview>`__.
 
+.. _terra-limitations:
+
 Limitations
 -----------
 
@@ -43,8 +45,8 @@ Limitations
    Dockstore are currently not supported.
 2. Terra does not currently support file-path based imports. Importing a
    workflow with file-based imports will result in error. See the
-   `converting file-based imports
-   doc <../end-user-topics/language-support.html#converting-file-path-based-imports-to-public-http-s-based-imports-for-wdl>`__
+   :ref:`converting file-based imports
+   doc <converting-file-path-based-imports-to-public-http-s-based-imports-for-wdl>`
    for more info.
 3. Only the WDL language is supported.
 

--- a/docs/news/2017-05-05-Upcoming-Features.rst
+++ b/docs/news/2017-05-05-Upcoming-Features.rst
@@ -22,8 +22,8 @@ of Dockstore, we're looking at features in the following main areas:
    register and publish the tool on Dockstore in just 2 commands.
    Publishing tools on Dockstore has gotten a lot easier. See
    `GitHub <https://github.com/dockstore/write_api_service/>`__ for more
-   info on how to use the Write API. See `this
-   doc </docs/publisher-tutorials/ways-to-register-tools-on-dockstore/>`__
+   info on how to use the Write API. See :doc:`this
+   doc </getting-started/dockstore-tools>`
    for information on different ways to register tools on Dockstore and
    when to use this Write API.
 

--- a/docs/news/2018-04-05-Dockstore-1.4.0.rst
+++ b/docs/news/2018-04-05-Dockstore-1.4.0.rst
@@ -33,11 +33,11 @@ Highlighted new features include:
    update it more often
 -  CLI
 -  ability to
-   `configure <../advanced-topics/advanced-features.html#alternative-cwl-launchers>`__
+   :ref:`configure <alternative-cwl-launchers>`
    Cromwell and Bunny (rabix) version or use the `generic cwl-runner
    interface <https://github.com/common-workflow-language/cwltool/blob/master/cwltool/schemas/v1.1.0-dev1/cwl-runner.cwl>`__
    to run cwl
--  ability to `POST notifications <../advanced-topics/advanced-features.html#notifications>`__
+-  ability to :ref:`POST notifications <notifications>`
    during workflow execution to a custom endpoint
 -  ability to run unpublished tools and workflows (if you are the owner
    or in the organization for a tool or workflow)

--- a/docs/news/2018-09-12-Dockstore-1.5.0.rst
+++ b/docs/news/2018-09-12-Dockstore-1.5.0.rst
@@ -52,7 +52,7 @@ Highlighted new features include
 -  updates for cwltool support from 1.0.20170828135420 to
    1.0.20180403145700
 -  to elaborate,
-   `verified <../faq.html#what-is-a-verified-tool-or-workflow>`__
+   :ref:`verified <what-is-a-verified-tool-or-workflow>`
    workflows have been run in-house succesfully with these versions
 -  updates to use the Bitbucket 2.0 API and the GitLab V4 API
 -  a large number of UI improvements and usability improvements

--- a/docs/news/2019-04-08-Dockstore-1.6.0.rst
+++ b/docs/news/2019-04-08-Dockstore-1.6.0.rst
@@ -4,16 +4,16 @@ Dockstore 1.6.0
 Highlighted new features include
 --------------------------------
 
--  initial support for `organizations and
-   collections <../advanced-topics/organizations-and-collections.html>`_
+-  initial support for :doc:`organizations and
+   collections </advanced-topics/organizations-and-collections>`
 -  institutions, grant agencies, consortiums, and more can now organize,
    describe, and highlight worthy workflows and tools found on Dockstore
 -  language support updates
 -  cwltool updates from 1.0.20180403145700 to 1.0.20181217162649
 -  cromwell updates from 30.2 to 36 (also a mode for CWL with Cromwell
-   via the `CLI <../advanced-topics/advanced-features.html#cromwell-beta>`_)
+   via the :ref:`CLI <cromwell-beta>`)
 -  to elaborate,
-   `verified <../faq.html#what-is-a-verified-tool-or-workflow>`_
+   :ref:`verified <what-is-a-verified-tool-or-workflow>`
    workflows have been run in-house succesfully with these versions but
    feel free to try newer versions as well and let us know if things are
    broken
@@ -27,7 +27,7 @@ Highlighted new features include
 
 -  beta support for launching workflows directly onto GA4GH WES
    endpoints
--  see our first steps at `WES CLI <../advanced-topics/advanced-features.html#workflow-execution-service-wes-command-line-interface-cli>`_
+-  see our first steps at :ref:`WES CLI <workflow-execution-service-wes-command-line-interface-cli>`
 -  launch-with support for `Terra <https://terra.bio/>`__
 -  improved display of validation errors
 -  support for

--- a/docs/news/2019-09-26-Dockstore-1.7.0.rst
+++ b/docs/news/2019-09-26-Dockstore-1.7.0.rst
@@ -4,10 +4,10 @@ Dockstore 1.7.0
 Highlighted new features include
 --------------------------------
 
-- `Snapshotted versions and DOIs <../advanced-topics/snapshot-and-doi.html>`_
+- :doc:`Snapshotted versions and DOIs </advanced-topics/snapshot-and-doi>`
   - Versions can be snapshotted to freeze them at a particular point in time
   - Zenodo integration allowing publishers to create DOIs for snapshotted versions
-- `CWL launch with CGC (Seven Bridges) <../launch-with/cgc-launch-with.html>`_
+- :doc:`CWL launch with CGC (Seven Bridges) </launch-with/cgc-launch-with>`
 - Language support updates
    - Support for WDL 1.0 tools and workflows
    - Support for CWL 1.1 tools and workflows
@@ -16,8 +16,8 @@ Highlighted new features include
 - When not logged-in, the home page will better introduce new users to Dockstore
 - CLI now tested with (and recommending) Java 11 and Python 3
 - Closed beta feature
-   - Services as `as a new type of entry <../getting-started/getting-started-with-services.html>`_
-   - Also `beta testing GitHub Apps and dockstore.yml <../getting-started/github-apps.html>`_
+   - Services as :doc:`as a new type of entry </getting-started/getting-started-with-services>`
+   - Also :doc:`beta testing GitHub Apps and dockstore.yml </getting-started/github-apps/github-apps-landing-page>`
 
 See a full list of our changes on
 `GitHub <https://github.com/dockstore/dockstore/milestone/25>`_


### PR DESCRIPTION
Ticket: https://ucsc-cgl.atlassian.net/browse/DOCK-1621

Links can be represented with different roles, [sphinx docs](https://www.sphinx-doc.org/en/master/usage/restructuredtext/roles.html), the command `make linkcheck` specifically expects external links, which is why all our local links were flagged as broken. Here are some approaches that can be used for links:
1. external links:
<code>\`text \<url\>\`</code>
2. link to a local document:
<code>:doc:\`text \</path/to/rst/file\>\`</code>
3. link to specific place in a local document:
   3a. Create a label in the document you want to link to with the following: <code>.. _<b>label-name</b>:</code> ( _ before label name is required)
   3b. link to the label with: <code>:ref:\`text \<label-name\>\`</code>