### PR TITLE
SEAB-2745 - Add 1.10.0 release notes to docs.dockstore.org

### DIFF
--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -11,7 +11,7 @@ Highlighted new features include:
 
 -  GitHub app support for filters to allow for more control over which tags and branches are automatically reported to Dockstore.
 
-   -  More details `here <../getting-started/github-apps/github-apps.html>`__.
+   -  More details `here ../getting-started/github-apps/github-apps.html`_.
 
 -  Ability to select a specific version of a workflow or tool when adding them to a collection ("I vouch for specifically version X of workflow Y").
 

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -28,7 +28,7 @@ Highlighted new features include:
 
 -  A significant number of bugfixes for everything from WDL parsing, UI display issues, editing of hosted workflows, and command-line interface fixes.
 
-See a full list of our changes on | GitHub |.
+See a full list of our changes on |GitHub|.
 
 Breaking changes
 ----------------

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -11,7 +11,7 @@ Highlighted new features include:
 
 -  GitHub app support for filters to allow for more control over which tags and branches are automatically reported to Dockstore.
 
-   -  More details `here ../getting-started/github-apps/github-apps.html`_.
+   -  More details `here ../getting-started/github-apps/github-apps`_.
 
 -  Ability to select a specific version of a workflow or tool when adding them to a collection ("I vouch for specifically version X of workflow Y").
 

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -43,4 +43,4 @@ Minor
 ~~~~~
 -  None
 
-.. _here:  <../getting-started/github-apps/github-apps.html?highlight=filters>
+.. _here: ../getting-started/github-apps/github-apps.html?highlight=filters

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -6,7 +6,7 @@ Highlighted new features include:
 
 -  GitHub app support for filters to allow for more control over which tags and branches are automatically reported to Dockstore.
 
-   -  More details :ref: `here <../getting-started/github-apps/github-apps.html?highlight=filters>`_.
+   -  More details :doc:`here <../getting-started/github-apps/github-apps.html?highlight=filters>`_.
 
 -  Ability to select a specific version of a workflow or tool when adding them to a collection ("I vouch for specifically version X of workflow Y").
 

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -28,7 +28,7 @@ Highlighted new features include:
 
 -  A significant number of bugfixes for everything from WDL parsing, UI display issues, editing of hosted workflows, and command-line interface fixes.
 
-See a full list of our changes on |GitHub|.
+See a full list of our changes on | GitHub |.
 
 Breaking changes
 ----------------
@@ -43,5 +43,5 @@ Minor
 ~~~~~
 -  None
 
-.. |GitHub|  raw:: html
+.. | GitHub |  raw:: html
    <a href="https://github.com/dockstore/dockstore/milestone/37?closed=1" target="_blank">GitHub</a>

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -6,7 +6,7 @@ Highlighted new features include:
 
 -  GitHub app support for filters to allow for more control over which tags and branches are automatically reported to Dockstore.
 
-   -  More details :doc:`here ../getting-started/github-apps/github-apps.html?highlight=filters` .
+   -  More details :doc:`here`_.
 
 -  Ability to select a specific version of a workflow or tool when adding them to a collection ("I vouch for specifically version X of workflow Y").
 
@@ -42,3 +42,5 @@ Major
 Minor
 ~~~~~
 -  None
+
+.. _here:  <../getting-started/github-apps/github-apps.html?highlight=filters>

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -6,8 +6,8 @@ Highlighted new features include:
 
 -  GitHub app support for filters to allow for more control over which tags and branches are automatically reported to Dockstore.
 
-   -  More details `here <https://docs.dockstore.org/en/develop/getting-started/github-apps/github-apps.html?highlight=filters>`_.
-   
+   -  More details `here <../getting-started/github-apps/github-apps.html?highlight=filters>`_.
+
 -  Ability to select a specific version of a workflow or tool when adding them to a collection ("I vouch for specifically version X of workflow Y").
 
 -  Update support for cwltool from 1.0.20190621234233 to 3.0.20200807132242.
@@ -23,14 +23,14 @@ Highlighted new features include:
 -  Behind the scenes:
 
    -  A large number of deployment and architectural changes to facilitate better security and regulatory compliance.
-   
-   -  Updates to elastic search and angular.
-   
--  A significant number of bugfixes for everything from WDL parsing, UI display issues, editing of hosted workflows, and command-line interface fixes.
- 
-See a full list of our changes on `GitHub <https://github.com/dockstore/dockstore/milestone/37>`_.
 
-Breaking changes 
+   -  Updates to elastic search and angular.
+
+-  A significant number of bugfixes for everything from WDL parsing, UI display issues, editing of hosted workflows, and command-line interface fixes.
+
+See a full list of our changes on |GitHub|.
+
+Breaking changes
 ----------------
 
 -  None known
@@ -43,5 +43,6 @@ Minor
 ~~~~~
 -  None
 
-.. _GitHub: https://github.com/dockstore/dockstore/milestone/37
-.. _here: https://docs.dockstore.org/en/develop/advanced-topics/checksum-support.html
+.. |GitHub|  raw:: html
+
+        <a href="https://github.com/dockstore/dockstore/milestone/37?closed=1" target="_blank"</a>

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -6,7 +6,7 @@ Highlighted new features include:
 
 -  GitHub app support for filters to allow for more control over which tags and branches are automatically reported to Dockstore.
 
-   -  More details `here <../getting-started/github-apps/github-apps.html>`_.
+   -  More details `here <../getting-started/github-apps/github-apps.html>`__.
 
 -  Ability to select a specific version of a workflow or tool when adding them to a collection ("I vouch for specifically version X of workflow Y").
 

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -43,4 +43,4 @@ Minor
 ~~~~~
 -  None
 
-.. _here: ../getting-started/github-apps/github-apps.html?highlight=filters
+.. _here: /getting-started/github-apps/github-apps.html?highlight=filters

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -5,16 +5,27 @@ Highlighted new features include:
 ---------------------------------
 
 -  GitHub app support for filters to allow for more control over which tags and branches are automatically reported to Dockstore.
+
    -  More details `here <https://docs.dockstore.org/en/develop/getting-started/github-apps/github-apps.html?highlight=filters>`_.
+   
 -  Ability to select a specific version of a workflow or tool when adding them to a collection ("I vouch for specifically version X of workflow Y").
+
 -  Update support for cwltool from 1.0.20190621234233 to 3.0.20200807132242.
+
 -  GitHub apps patches for more reliable processing of automatic updates.
+
 -  Performance improvements for large repositories with lots of branches and tags.
+
 -  Performance improvements for GA4GH TRS implementation.
+
 -  Initial phase of a more consistent visual experience for the site.
+
 -  Behind the scenes:
+
    -  A large number of deployment and architectural changes to facilitate better security and regulatory compliance.
+   
    -  Updates to elastic search and angular.
+   
 -  A significant number of bugfixes for everything from WDL parsing, UI display issues, editing of hosted workflows, and command-line interface fixes.
  
 See a full list of our changes on `GitHub <https://github.com/dockstore/dockstore/milestone/37>`_.

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -6,7 +6,7 @@ Highlighted new features include:
 
 -  GitHub app support for filters to allow for more control over which tags and branches are automatically reported to Dockstore.
 
-   -  More details :doc:`here <../getting-started/github-apps/github-apps.html?highlight=filters>`_.
+   -  More details :doc:`here <../getting-started/github-apps/github-apps.html?highlight=filters>`.
 
 -  Ability to select a specific version of a workflow or tool when adding them to a collection ("I vouch for specifically version X of workflow Y").
 

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -33,13 +33,15 @@ See a full list of our changes on `GitHub <https://github.com/dockstore/dockstor
 Breaking changes 
 ----------------
 
+-  None known
+
 Major
 ~~~~~
 -  None intended
 
 Minor
 ~~~~~
--  none
+-  None
 
 .. _GitHub: https://github.com/dockstore/dockstore/milestone/37
 .. _here: https://docs.dockstore.org/en/develop/advanced-topics/checksum-support.html

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -43,4 +43,5 @@ Minor
 ~~~~~
 -  None
 
-.. |GitHub|  <a href="https://github.com/dockstore/dockstore/milestone/37?closed=1" target="_blank"</a>
+.. |GitHub|  raw:: html
+   <a href="https://github.com/dockstore/dockstore/milestone/37?closed=1" target="_blank">GitHub</a>

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -6,7 +6,7 @@ Highlighted new features include:
 
 -  GitHub app support for filters to allow for more control over which tags and branches are automatically reported to Dockstore.
 
-   -  More details `here <../getting-started/github-apps/github-apps>`_.
+   -  More details :doc:`here <../getting-started/github-apps/github-apps>`.
 
 -  Ability to select a specific version of a workflow or tool when adding them to a collection ("I vouch for specifically version X of workflow Y").
 

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -1,17 +1,12 @@
 Dockstore 1.10.0
 ================
 
-\ |version|
-\ |release|
-\ |language|
-\ |locale_dirs|
-
 Highlighted new features include:
 ---------------------------------
 
 -  GitHub app support for filters to allow for more control over which tags and branches are automatically reported to Dockstore.
 
-   -  More details :doc:`here ../getting-started/github-apps/github-apps`_.
+   -  More details :doc:`here <../getting-started/github-apps/github-apps>`_.
 
 -  Ability to select a specific version of a workflow or tool when adding them to a collection ("I vouch for specifically version X of workflow Y").
 

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -1,6 +1,11 @@
 Dockstore 1.10.0
 ================
 
+\ |version|
+\ |release|
+\ |language|
+\ |locale_dirs|
+
 Highlighted new features include:
 ---------------------------------
 

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -6,7 +6,7 @@ Highlighted new features include:
 
 -  GitHub app support for filters to allow for more control over which tags and branches are automatically reported to Dockstore.
 
-   -  More details :doc:`here`_.
+   -  More details `here`_.
 
 -  Ability to select a specific version of a workflow or tool when adding them to a collection ("I vouch for specifically version X of workflow Y").
 

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -43,4 +43,4 @@ Minor
 ~~~~~
 -  None
 
-.. _here: /getting-started/github-apps/github-apps.html
+.. _here: ../getting-started/github-apps/github-apps.html

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -6,7 +6,7 @@ Highlighted new features include:
 
 -  GitHub app support for filters to allow for more control over which tags and branches are automatically reported to Dockstore.
 
-   -  More details :doc:`here <../getting-started/github-apps/github-apps>`_.
+   -  More details `here <../getting-started/github-apps/github-apps>`_.
 
 -  Ability to select a specific version of a workflow or tool when adding them to a collection ("I vouch for specifically version X of workflow Y").
 

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -6,7 +6,7 @@ Highlighted new features include:
 
 -  GitHub app support for filters to allow for more control over which tags and branches are automatically reported to Dockstore.
 
-   -  More details :doc:`here <../getting-started/github-apps/github-apps.html?highlight=filters>` .
+   -  More details :doc:`here ../getting-started/github-apps/github-apps.html?highlight=filters` .
 
 -  Ability to select a specific version of a workflow or tool when adding them to a collection ("I vouch for specifically version X of workflow Y").
 

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -11,7 +11,7 @@ Highlighted new features include:
 
 -  GitHub app support for filters to allow for more control over which tags and branches are automatically reported to Dockstore.
 
-   -  More details `here ../getting-started/github-apps/github-apps`_.
+   -  More details :doc:`here ../getting-started/github-apps/github-apps`_.
 
 -  Ability to select a specific version of a workflow or tool when adding them to a collection ("I vouch for specifically version X of workflow Y").
 

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -43,4 +43,4 @@ Minor
 ~~~~~
 -  None
 
-.. _here: /getting-started/github-apps/github-apps.html?highlight=filters
+.. _here: /getting-started/github-apps/github-apps.html

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -6,7 +6,7 @@ Highlighted new features include:
 
 -  GitHub app support for filters to allow for more control over which tags and branches are automatically reported to Dockstore.
 
-   -  More details :doc:`here <../getting-started/github-apps/github-apps.html>`_.
+   -  More details `here <../getting-started/github-apps/github-apps.html>`_.
 
 -  Ability to select a specific version of a workflow or tool when adding them to a collection ("I vouch for specifically version X of workflow Y").
 

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -6,7 +6,7 @@ Highlighted new features include:
 
 -  GitHub app support for filters to allow for more control over which tags and branches are automatically reported to Dockstore.
 
-   -  More details :doc:`here <../getting-started/github-apps/github-apps.html?highlight=filters>`.
+   -  More details :doc:`here <../getting-started/github-apps/github-apps.html?highlight=filters>` .
 
 -  Ability to select a specific version of a workflow or tool when adding them to a collection ("I vouch for specifically version X of workflow Y").
 

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -6,7 +6,7 @@ Highlighted new features include:
 
 -  GitHub app support for filters to allow for more control over which tags and branches are automatically reported to Dockstore.
 
-   -  More details :doc:`here <../getting-started/github-apps/github-apps.html>`.
+   -  More details :doc:`here <../getting-started/github-apps/github-apps.html>`_.
 
 -  Ability to select a specific version of a workflow or tool when adding them to a collection ("I vouch for specifically version X of workflow Y").
 

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -28,7 +28,7 @@ Highlighted new features include:
 
 -  A significant number of bugfixes for everything from WDL parsing, UI display issues, editing of hosted workflows, and command-line interface fixes.
 
-See a full list of our changes on |GitHub|.
+See a full list of our changes on `GitHub <https://github.com/dockstore/dockstore/milestone/37?closed=1>`_.
 
 Breaking changes
 ----------------
@@ -42,6 +42,3 @@ Major
 Minor
 ~~~~~
 -  None
-
-.. | GitHub |  raw:: html
-   <a href="https://github.com/dockstore/dockstore/milestone/37?closed=1" target="_blank">GitHub</a>

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -43,5 +43,4 @@ Minor
 ~~~~~
 -  None
 
-.. |GitHub|  raw:: html
-        <a href="https://github.com/dockstore/dockstore/milestone/37?closed=1" target="_blank"</a>
+.. |GitHub|  <a href="https://github.com/dockstore/dockstore/milestone/37?closed=1" target="_blank"</a>

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -44,5 +44,4 @@ Minor
 -  None
 
 .. |GitHub|  raw:: html
-
         <a href="https://github.com/dockstore/dockstore/milestone/37?closed=1" target="_blank"</a>

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -6,7 +6,7 @@ Highlighted new features include:
 
 -  GitHub app support for filters to allow for more control over which tags and branches are automatically reported to Dockstore.
 
-   -  More details `here <../getting-started/github-apps/github-apps.html?highlight=filters>`_.
+   -  More details :ref: `here <../getting-started/github-apps/github-apps.html?highlight=filters>`_.
 
 -  Ability to select a specific version of a workflow or tool when adding them to a collection ("I vouch for specifically version X of workflow Y").
 

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -1,0 +1,34 @@
+Dockstore 1.10.0
+================
+
+Highlighted new features include:
+---------------------------------
+
+-  GitHub app support for filters to allow for more control over which tags and branches are automatically reported to Dockstore.
+   -  More details `here <https://docs.dockstore.org/en/develop/getting-started/github-apps/github-apps.html?highlight=filters>`_.
+-  Ability to select a specific version of a workflow or tool when adding them to a collection ("I vouch for specifically version X of workflow Y").
+-  Update support for cwltool from 1.0.20190621234233 to 3.0.20200807132242.
+-  GitHub apps patches for more reliable processing of automatic updates.
+-  Performance improvements for large repositories with lots of branches and tags.
+-  Performance improvements for GA4GH TRS implementation.
+-  Initial phase of a more consistent visual experience for the site.
+-  Behind the scenes:
+   -  A large number of deployment and architectural changes to facilitate better security and regulatory compliance.
+   -  Updates to elastic search and angular.
+-  A significant number of bugfixes for everything from WDL parsing, UI display issues, editing of hosted workflows, and command-line interface fixes.
+ 
+See a full list of our changes on `GitHub <https://github.com/dockstore/dockstore/milestone/37>`_.
+
+Breaking changes 
+----------------
+
+Major
+~~~~~
+-  None intended
+
+Minor
+~~~~~
+-  none
+
+.. _GitHub: https://github.com/dockstore/dockstore/milestone/37
+.. _here: https://docs.dockstore.org/en/develop/advanced-topics/checksum-support.html

--- a/docs/news/2020-12-03-Dockstore-1.10.0.rst
+++ b/docs/news/2020-12-03-Dockstore-1.10.0.rst
@@ -6,7 +6,7 @@ Highlighted new features include:
 
 -  GitHub app support for filters to allow for more control over which tags and branches are automatically reported to Dockstore.
 
-   -  More details `here`_.
+   -  More details :doc:`here <../getting-started/github-apps/github-apps.html>`.
 
 -  Ability to select a specific version of a workflow or tool when adding them to a collection ("I vouch for specifically version X of workflow Y").
 
@@ -43,4 +43,4 @@ Minor
 ~~~~~
 -  None
 
-.. _here: ../getting-started/github-apps/github-apps.html
+.. _here: 


### PR DESCRIPTION
This was taken from GitHub with the modifications I made the other day and converted to reStructured Text.

I've reviewed it readthedocs.org. 
