### PR TITLE
Add help on checksum verification

### DIFF
--- a/docs/advanced-topics/checksum-support.rst
+++ b/docs/advanced-topics/checksum-support.rst
@@ -68,7 +68,7 @@ use Docker images referred to by a tagged version or digest. The verification fe
 
 For more information on Docker registry retention policies see posts from `Docker <https://www.docker.com/blog/scaling-dockers-business-to-serve-millions-more-developers-storage/`_,
 `AWS <https://aws.amazon.com/blogs/compute/clean-up-your-container-images-with-amazon-ecr-lifecycle-policies/>`_,
-or `Azure <https://docs.microsoft.com/en-us/azure/container-registry/container-registry-retention-policy>`_ documentation.
+or `Azure <https://docs.microsoft.com/en-us/azure/container-registry/container-registry-retention-policy>`_.
 
 Tools
 -----

--- a/docs/advanced-topics/checksum-support.rst
+++ b/docs/advanced-topics/checksum-support.rst
@@ -61,10 +61,14 @@ Docker CLI client.
 When the download has completed a Digest is provided in the terminal output. This should match the checksum provided
 by the Dockstore API.
 
-Verifying the image checksum can give you better guarantees the image has not changed since it was published to Dockstore.
+Verifying the image checksum can give you better guarantees the image has not changed since the workflow was published to Dockstore.
 However, in some cases the image checksum may diverge, for example, if the image was defined in a git branch that has since
-been updated. For best results use Docker images referred to by a tagged version or digest. The verification features
-available may vary between execution engines.
+been updated. For best results, and to avoid your Docker image being deleted because of a registry's retention policy,
+use Docker images referred to by a tagged version or digest. The verification features available may vary between execution engines.
+
+For more information on Docker registry retention policies see posts from `Docker <https://www.docker.com/blog/scaling-dockers-business-to-serve-millions-more-developers-storage/`_,
+`AWS <https://aws.amazon.com/blogs/compute/clean-up-your-container-images-with-amazon-ecr-lifecycle-policies/>`_,
+or `Azure <https://docs.microsoft.com/en-us/azure/container-registry/container-registry-retention-policy>`_ documentation.
 
 Tools
 -----

--- a/docs/advanced-topics/checksum-support.rst
+++ b/docs/advanced-topics/checksum-support.rst
@@ -23,6 +23,7 @@ After gathering the checksum using the above method you can verify a descriptor'
 This is done by requesting the PLAIN_WDL descriptor and piping the output to sha1sum.
 
 ::
+
     trsid=%23workflow%2Fgithub.com%2Fdockstore-testing%2Fdockstore-workflow-md5sum-unified%2Fwdl
     version=1.2.0
     curl -s https://dockstore.org/api/ga4gh/trs/v2/tools/$trsid/versions/$version/PLAIN-WDL/descriptor | sha1sum

--- a/docs/advanced-topics/checksum-support.rst
+++ b/docs/advanced-topics/checksum-support.rst
@@ -19,6 +19,16 @@ More specifically, the endpoints that contain checksums for files are as follows
 
 The id parameter used in the endpoints above can be found on an entry's public page; underneath the Info tab, look for the bolded words **TRS**.
 
+After gathering the checksum using the above method you can verify a descriptor's using the sha1sum terminal application.
+This is done by requesting the PLAIN_WDL descriptor and piping the output to sha1sum.
+
+::
+    trsid=%23workflow%2Fgithub.com%2Fdockstore-testing%2Fdockstore-workflow-md5sum-unified%2Fwdl
+    version=1.2.0
+    curl -s https://dockstore.org/api/ga4gh/trs/v2/tools/$trsid/versions/$version/PLAIN-WDL/descriptor | sha1sum
+
+The resulting checksum should match what was provided by the API above.
+
 Docker Image Checksum Support
 =============================
 Checksum support for Docker images is more nuanced than it is for files. For quick reference, the table below displays the languages and
@@ -36,6 +46,17 @@ Descriptions for the two endpoints of note are as follows:
 - To see a single version of an entry, go `here <https://dockstore.org/api/static/swagger-ui/index.html#/GA4GHV20/toolsIdVersionsVersionIdGet>`_ and fill out id and version_id
 
 Just like the file endpoints, the id parameter used in the endpoints above can be found on an entry's public page; underneath the Info tab, look for the bolded words **TRS**.
+
+To verify a checksum as reported by the Dockstore API matches what you download from the Docker repository first find the checksum
+and image path and registry using one of the above methods for the image you would like to verify. Then download the image using the
+Docker CLI client.
+
+::
+
+    docker pull quay.io/briandoconnor/dockstore-tool-md5sum:1.0.4
+
+When the download has completed a Digest is provided in the terminal output. This should match the checksum provided
+by the Dockstore API.
 
 Tools
 -----

--- a/docs/advanced-topics/checksum-support.rst
+++ b/docs/advanced-topics/checksum-support.rst
@@ -61,8 +61,10 @@ Docker CLI client.
 When the download has completed a Digest is provided in the terminal output. This should match the checksum provided
 by the Dockstore API.
 
-Depending on your execution engine, the image may be downloaded using another technique and may not have its checksum
-verified.
+Verifying the image checksum can give you better guarantees the image has not changed since it was published to Dockstore.
+However, in some cases the image checksum may diverge, for example, if the image was defined in a git branch that has since
+been updated. For best results use Docker images referred to by a tagged version or digest. The verification features
+available may vary between execution engines.
 
 Tools
 -----

--- a/docs/advanced-topics/checksum-support.rst
+++ b/docs/advanced-topics/checksum-support.rst
@@ -19,7 +19,7 @@ More specifically, the endpoints that contain checksums for files are as follows
 
 The id parameter used in the endpoints above can be found on an entry's public page; underneath the Info tab, look for the bolded words **TRS**.
 
-After gathering the checksum using the above method you can verify a descriptor's using the sha1sum terminal application.
+After gathering the checksum using the above method you can verify a descriptor's checksum using the sha1sum terminal application.
 This is done by requesting the PLAIN_WDL descriptor and piping the output to sha1sum.
 
 ::
@@ -50,8 +50,8 @@ Descriptions for the two endpoints of note are as follows:
 
 Just like the file endpoints, the id parameter used in the endpoints above can be found on an entry's public page; underneath the Info tab, look for the bolded words **TRS**.
 
-To verify a checksum as reported by the Dockstore API matches what you download from the Docker repository first find the checksum
-and image path and registry using one of the above methods for the image you would like to verify. Then download the image using the
+To verify a checksum as reported by the Dockstore API matches what you download from the Docker registry first find the checksum
+and image path using one of the above methods for the image you would like to verify. Then download the image using the
 Docker CLI client.
 
 ::

--- a/docs/advanced-topics/checksum-support.rst
+++ b/docs/advanced-topics/checksum-support.rst
@@ -29,6 +29,8 @@ This is done by requesting the PLAIN_WDL descriptor and piping the output to sha
 
 The resulting checksum should match what was provided by the API above.
 
+If you use the Dockstore CLI client descriptor checksums are verified before being sent to the execution engine.
+
 Docker Image Checksum Support
 =============================
 Checksum support for Docker images is more nuanced than it is for files. For quick reference, the table below displays the languages and
@@ -57,6 +59,9 @@ Docker CLI client.
 
 When the download has completed a Digest is provided in the terminal output. This should match the checksum provided
 by the Dockstore API.
+
+Depending on your execution engine, the image may be downloaded using another technique and may not have its checksum
+verified.
 
 Tools
 -----

--- a/docs/advanced-topics/checksum-support.rst
+++ b/docs/advanced-topics/checksum-support.rst
@@ -19,14 +19,14 @@ More specifically, the endpoints that contain checksums for files are as follows
 
 The id parameter used in the endpoints above can be found on an entry's public page; underneath the Info tab, look for the bolded words **TRS**.
 
-After gathering the checksum using the above method you can verify a descriptor's checksum using the sha1sum terminal application.
-This is done by requesting the PLAIN_WDL descriptor and piping the output to sha1sum.
+After gathering the checksum using the above method you can verify a descriptor's checksum using the shasum terminal application.
+This is done by requesting the PLAIN_WDL descriptor and piping the output to shasum.
 
 ::
 
     trsid=%23workflow%2Fgithub.com%2Fdockstore-testing%2Fdockstore-workflow-md5sum-unified%2Fwdl
     version=1.2.0
-    curl -s https://dockstore.org/api/ga4gh/trs/v2/tools/$trsid/versions/$version/PLAIN-WDL/descriptor | sha1sum
+    curl -s https://dockstore.org/api/ga4gh/trs/v2/tools/$trsid/versions/$version/PLAIN-WDL/descriptor | shasum
 
 The resulting checksum should match what was provided by the API above.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -180,4 +180,4 @@ epub_exclude_files = ['search.html']
 discourse_url = 'https://discuss.dockstore.org/'
 
 def setup(app):
-    app.add_stylesheet('css/extra.css')
+    app.add_css_file('css/extra.css')


### PR DESCRIPTION
We added notes on checking the presence of checksums but not verifying them. This improves the status of that slightly and mentions the CLI feature verifying descriptor checksums.

https://ucsc-cgl.atlassian.net/browse/SEAB-1510