### PR TITLE
Add link to 1.11 Release Notes on GitHub

### DIFF
--- a/docs/news/2021-07-14-Dockstore-1.11.5.rst
+++ b/docs/news/2021-07-14-Dockstore-1.11.5.rst
@@ -1,0 +1,9 @@
+Dockstore 1.11.5
+================
+
+Release Notes
+-------------
+
+Release Notes can be found on the `GitHub Changelog page <https://github.com/dockstore/dockstore/releases/tag/1.11.5>`_
+
+.. _here: 


### PR DESCRIPTION
Added a file that now references the 1.11.5 version description on GitHub for the 1.11 release notes.

This is a change in that previously docs.docstore.org hosted its own copy of the release notes.

This does not contain the style_external_links change since that depends on the logo work which is still in the 'develop' branch.