### PR TITLE
Enable html_theme_options:style_external_links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,7 +84,7 @@ html_theme = 'sphinx_rtd_theme'
 html_theme_options = {
 	'logo_only' : True,
 	'display_version' : True,
-#	'style_external_links' : True,
+	'style_external_links' : True,
 }
 
 # Theme options are theme-specific and customize the look and feel of a theme


### PR DESCRIPTION
Enable the setting that displays an external link indicator at the end of any links in the documentation that leave docs.dockstore.org.

This is a config file setting that, at the end of eternal links ![display a box with an arrow pointing from the lower-left corner and passing through the upper right corner](https://user-images.githubusercontent.com/15311001/132060268-c2f4d977-8192-4ea9-8646-3ac3bd5db4c7.png).  

It does not display on external links in the Table of Contents section of the documentation.  I have been unable to find an option for that instance.

