### PR TITLE
Fix markdown file's headers

### DIFF
--- a/docs/docker_instructions.md
+++ b/docs/docker_instructions.md
@@ -6,7 +6,6 @@ The Docker CLI is a command-line tool with a whole library of commands for inter
 
 
 ### Part A - Running Containers
----
 In this section you will try running a basic container called whalesay. Refer to the [part A readings](#part-a-readings) if you need a refresher on the content taught in the training.
 
 Run whalesay with the following command:
@@ -37,7 +36,6 @@ docker run docker/whalesay cowsay "hello"
 Now try getting the whale to say "Hello [your name]!".
 
 ### Part B - Exploring Containers
----
 We will now try running a container with [Samtools](http://www.htslib.org/) installed to convert a SAM file to a BAM file. Refer to the [part B readings](#part-b-readings) if you need a refresher on the content taught in the training.
 
 #### Sharing data between host and container


### PR DESCRIPTION
This fixes the warnings we've been getting during `make html`. This works with both our existing version of recommonmark and with #155. In other words this is not dependent on, but it is compatible with, #155.

This should be merged *before* #153.