### PR TITLE
replace recommonmark with myst-parser

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,8 +61,9 @@ templates_path = ['_templates']
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-
-
+#
+# Note that because we have the myst_parser extension, .md files we will
+# be rendered too, even though they are not listed below
 source_suffix = '.rst'
 
 # The master toctree document.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -41,7 +41,7 @@ user_agent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Ge
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['recommonmark', 'sphinxcontrib.discourse']
+extensions = ['myst_parser', 'sphinxcontrib.discourse']
 
 linkcheck_anchors = False
 linkcheck_ignore = [
@@ -61,6 +61,8 @@ templates_path = ['_templates']
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
+
+
 source_suffix = '.rst'
 
 # The master toctree document.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,12 +11,12 @@ future==0.18.2
 idna==3.2 
 imagesize==1.2.0 
 mock==1.0.1 
+myst_parser==0.16.0
 packaging==21.0 
 pillow==5.4.1 
 pyparsing==2.4.7 
 pytz==2021.3 
 readthedocs-sphinx-ext==2.1.4 
-recommonmark==0.5.0 
 requests==2.26.0 
 six==1.16.0 
 snowballstemmer==2.1.0 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sphinx
-recommonmark
+myst-parser
 sphinx_rtd_theme
 git+https://github.com/pdavide/sphinxcontrib-discourse


### PR DESCRIPTION
recommonmark is deprecated: https://github.com/readthedocs/recommonmark/issues/221

This is not an essential fix, just something I noticed while researching other errors.