### PR TITLE
Reorganize FAQ page

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,6 +1,201 @@
 FAQ
 ===
 
+General Dockstore Questions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+What environment do you test tools in?
+--------------------------------------
+
+Typically, we test running tools in Ubuntu Linux 16.04 LTS on VMs in
+`OpenStack <https://www.openstack.org/>`__ with 8 vCPUs and 96 GB of RAM
+and above. We've also begun testing on Ubuntu 18.04 LTS and so far it's
+been successful. If you are only listing and editing tools, we have
+achieved success with much lower system requirements. However, launching
+tools will have higher system requirements dependent on the specific
+tool. Consult a tool's README or CWL/WDL description when in doubt.
+
+
+.. _what-is-a-verified-tool-or-workflow:
+
+What is a verified tool or workflow?
+------------------------------------
+
+A verified tool/workflow means that at least one version has been verified to be successfully ran on a platform.
+
+See :doc:`/advanced-topics/verification` for full details on this feature.
+
+
+What is a default version of a tool or workflow?
+------------------------------------------------
+
+Every tool/workflow is recommended to have a default version set by its
+author. It indicates to the end users which version of the tool/workflow
+they should use. For tools, the default version is uniquely identified
+by the tag from the Docker image repository. For workflows, the default
+version is identified by the Git Reference (which could be a Git tag or
+a Git branch). The default version can be set in the 'Versions' tab of a
+tool/workflow via radio buttons.
+
+Setting the default version affects a number of elements including (but
+not limited to):
+
+1. It determines what is displayed in the 'Description' section of the
+   'Info' Tab
+2. It is the first version other end users see when no version is
+   specified. For example
+   https://dockstore.org/containers/quay.io/pancancer/pcawg-bwa-mem-workflow
+   is redirected to
+   https://dockstore.org/containers/quay.io/pancancer/pcawg-bwa-mem-workflow:develop?tab=info
+3. It is the version of the tool/workflow that is launched by default
+   when users launch a tool/workflow from the Dockstore CLI.
+   For example, if version 1.0 is set as the default version of the
+   quay.io/cancercollaboratory/dockstore-tool-bedgraph-bigwig tool,
+
+    ``$ dockstore tool launch --entry quay.io/cancercollaboratory/dockstore-tool-bedgraph-bigwig:1.0 --json Dockstore.json`` 
+    
+    would be equivalent to
+
+    ``$ dockstore tool launch --entry quay.io/cancercollaboratory/dockstore-tool-bedgraph-bigwig --json Dockstore.json``
+4. The docker pull command in the tools search reflects the defaultversion
+
+How can I use the Dockstore CLI with Python 2?
+----------------------------------------------
+
+Python 2 support ended in 2020. You can get the Python 2 requirements.txt with ``curl -o requirements.txt "https://dockstore.org/api/metadata/runner_dependencies?python_version=2"``
+but it is currently untested.
+
+
+
+How do I send private messages to administrators or report security vulnerabilities?
+------------------------------------------------------------------------------------
+
+Users are able to open helpdesk tickets on `Discourse <https://discuss.dockstore.org/>`_. Users can create helpdesk tickets in
+case of privacy complaints, security vulnerabilities, or any other urgent matter related to Dockstore. Helpdesk tickets will be addressed
+by Dockstore administrators.
+
+The following steps can be taken to create a helpdesk ticket (also shown `here <https://discuss.dockstore.org/t/opening-helpdesk-tickets/1506>`_).
+
+1. Navigate to `Discourse <https://discuss.dockstore.org/>`_ and login.
+2. Select your profile icon, located in the top right corner of the screen.
+3. Select the ``mail`` icon, located in the dropdown.
+4. Send a message to the ``dockstore_admins`` group.
+
+.. Note:: If you are unable to see a ``New Message`` button on the mail page, you may be considered a new user and have insufficient privileges. \
+   Entering 5 topics and viewing 30 posts over a minimum of 10 minutes will raise your privileges. \
+   You will be notified of any privilege changes to your account via the mailbox.
+
+
+How do I cite Dockstore?
+------------------------
+
+For citing Dockstore as a paper, take a look at our `F1000
+paper <http://dx.doi.org/10.12688/f1000research.10137.1>`__.
+
+For citing the actual code, we recommend looking at our Zenodo entry.
+You will find a variety of citation styles and ways to export it at
+|DOI|.
+
+Dockstore CLI
+^^^^^^^^^^^^^
+
+How does launching with Dockstore CLI compare with cwltool?
+-----------------------------------------------------------
+
+The Dockstore CLI has utilities to generate JSON parameter files from
+entries on Dockstore (``dockstore tool convert``).
+
+When launching tools, the Dockstore CLI makes it easy to specify entries
+from Dockstore. We can also provision input and output files using HTTP,
+FTP, and S3. We also have preliminary support for
+`Synapse <https://www.synapse.org/>`__ and the `ICGC Storage
+client <https://docs.icgc.org/download/guide/#score-client-usage>`__.
+Please see `file provisioning
+plugins <https://github.com/dockstore/dockstore-cli/tree/master/dockstore-file-plugin-parent>`__
+for more information on these two file transfer sources.
+
+
+.. _how-do-i-use-the-dockstore-cli-on-a-mac:
+
+How do I use the Dockstore CLI on a Mac?
+----------------------------------------
+
+See `Docker for Mac <https://docs.docker.com/engine/installation/mac/>`__ for installation information.
+
+.. note:: Docker behaves a bit differently on a
+    `Mac <https://docs.docker.com/docker-for-mac/osxfs/#/namespaces>`__ than
+    on a typical Ubuntu machine. By default the only shared volumes are
+    /Users, /Volumes, /tmp, and /private. Note that /var is not a shared
+    directory (and can't be set as one). ``cwltool`` uses your TMPDIR (the
+    env variable) to setup volumes with docker, which on a Mac can default
+    to a subdirectory of /var. In order to get ``cwltool`` working on your
+    Mac, you need to set your TMPDIR to be under one of the shared volumes
+    in Docker for Mac. You can do this by doing something similar to the
+    following:
+    ::
+
+        export TMPDIR=/tmp/docker_tmp
+
+By default, Docker for Mac allocates fewer resources (CPU, Memory, Swap)
+to containers compared to what is available on your host machine. You
+can change what it allocates using the Docker for Mac GUI under
+``Preferences > Advanced`` as described
+`here <https://docs.docker.com/docker-for-mac/#advanced>`__.
+
+* The default allocation can cause workflows or tools to fail without informing the user with a memory or resource related error message. If you find that your workflow or tool is behaving differently on a Mac compared to a similarly resourced Ubuntu environment, you can try increasing the resources allocated to Docker on the Mac to resolve the discrepancy.
+
+
+The CLI is failing with Java 8
+------------------------------
+
+If you see the following error when running the Dockstore CLI, you need
+to upgrade your Java version:
+
+::
+
+    $ dockstore
+    Error: A JNI error has occurred, please check your installation and try again
+    Exception in thread "main" java.lang.UnsupportedClassVersionError: io/dockstore/client/cli/Client has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
+
+The Dockstore CLI as of 1.7.0 is compiled and tested using Java 11 due
+to the Java 8 EOL. You will need to upgrade from Java 8 to use the CLI.
+
+
+How do I launch tools/workflows without internet access on compute nodes?
+-------------------------------------------------------------------------
+
+Some tools/workflows require Docker images to launch even if they are
+local entries. If the compute nodes do not have internet access, you can
+follow these steps:
+
+1. download the Docker image(s) on the head node which does have internet access using the ``docker save -o <filename> <imagename>``
+2. ensure that the ``<imagename>`` matches the image name specific in the CWL or WDL descriptor 
+3. place the image file(s) in a location that the compute nodes have access to (make sure there are only images in that directory)
+4. specify in the dockstore config file (default ~/.dockstore/config) the directory that contains your image(s) using ``docker-images = /home/user/docker_images_directory``
+
+The Dockstore CLI will automatically load all Docker images in the
+directory specified prior to a ``launch --local-entry`` command
+
+
+
+Integration with GitHub
+^^^^^^^^^^^^^^^^^^^^^^^
+
+What is the difference between logging in with GitHub or logging in with Google?
+--------------------------------------------------------------------------------
+
+The intent here is that you should be able to login with either login
+method and still conveniently get into the same Dockstore account. With
+login via Google, if you are a Terra user you will also have access to
+:doc:`sharing functionality </advanced-topics/sharing-workflows>`.
+
+Note that for simplicity, each of your GitHub or Google accounts can
+only be associated with one account at a time. You will need to link
+with a different account for each login method or delete your account if
+you want to assign them to a new Dockstore account.
+
+
+
 What happens if I rename my GitHub repository?
 ----------------------------------------------
 
@@ -19,46 +214,49 @@ your account in the future, do not reuse the original name of the renamed
 repository. If you do, redirects to the renamed repository will break.
 
 
-How does launching with Dockstore CLI compare with cwltool?
------------------------------------------------------------
 
-The Dockstore CLI has utilities to generate JSON parameter files from
-entries on Dockstore (``dockstore tool convert``).
 
-When launching tools, the Dockstore CLI makes it easy to specify entries
-from Dockstore. We can also provision input and output files using HTTP,
-FTP, and S3. We also have preliminary support for
-`Synapse <https://www.synapse.org/>`__ and the `ICGC Storage
-client <https://docs.icgc.org/download/guide/#score-client-usage>`__.
-Please see `file provisioning
-plugins <https://github.com/dockstore/dockstore-cli/tree/master/dockstore-file-plugin-parent>`__
-for more information on these two file transfer sources.
+Permissions
+^^^^^^^^^^^^
 
-What environment do you test tools in?
---------------------------------------
+How do I add other users as maintainers of a workflow?
+------------------------------------------------------
 
-Typically, we test running tools in Ubuntu Linux 16.04 LTS on VMs in
-`OpenStack <https://www.openstack.org/>`__ with 8 vCPUs and 96 GB of RAM
-and above. We've also begun testing on Ubuntu 18.04 LTS and so far it's
-been successful. If you are only listing and editing tools, we have
-achieved success with much lower system requirements. However, launching
-tools will have higher system requirements dependent on the specific
-tool. Consult a tool's README or CWL/WDL description when in doubt.
+For workflows registered with GitHub, Dockstore allows users from the same GitHub organization to manage workflows
+together. If a new GitHub workflow from the same GitHub organization is added to Dockstore by another user, click
+the "Discover Existing Dockstore Workflows" button in the "My Workflows" menu so the workflow will appear in My Workflows.
 
-The CLI is failing with Java 8
-------------------------------
+.. image:: discover_existing_workflows_screenshot.png
 
-If you see the following error when running the Dockstore CLI, you need
-to upgrade your Java version:
+If the workflow was added by manually registering it, click Refresh Organization.
 
-::
+For participants of the :doc:`limited sharing
+beta </advanced-topics/sharing-workflows/>`, you can enter the email
+addresses of the users you wish to share with to give them permissions
+to your workflow. This is only available for hosted workflows and users
+with Google accounts linked to Terra.
 
-    $ dockstore
-    Error: A JNI error has occurred, please check your installation and try again
-    Exception in thread "main" java.lang.UnsupportedClassVersionError: io/dockstore/client/cli/Client has been compiled by a more recent version of the Java Runtime (class file version 55.0), this version of the Java Runtime only recognizes class file versions up to 52.0
 
-The Dockstore CLI as of 1.7.0 is compiled and tested using Java 11 due
-to the Java 8 EOL. You will need to upgrade from Java 8 to use the CLI.
+Why are my workflows from an organization I belong to not visible?
+------------------------------------------------------------------
+
+Organizations have the ability to restrict access to the API for third
+party applications. GitHub provides a
+`tutorial <https://help.github.com/en/articles/enabling-oauth-app-access-restrictions-for-your-organization/>`__
+on how to add these restrictions to your organizations.
+
+In order for Dockstore to gain access to organizations of this type, you
+will need to grant access to the Dockstore application. Dockstore will
+only be reading information on workflows in your organization and who
+has access to them in order to mirror these restrictions on Dockstore
+itself. GitHub provides a
+`tutorial <https://help.github.com/en/articles/approving-oauth-apps-for-your-organization/>`__
+for approving third party apps access to your organization.
+
+
+
+Other
+^^^^^
 
 There are too many versions of my tool, how do I delete some?
 -------------------------------------------------------------
@@ -69,15 +267,6 @@ example <https://quay.io/repository/pancancer/pcawg-bwa-mem-workflow?tab=tags>`_
 If you have the right permissions, you can delete some and then refresh
 a tool on Dockstore to clean-up.
 
-How do I cite Dockstore?
-------------------------
-
-For citing Dockstore as a paper, take a look at our `F1000
-paper <http://dx.doi.org/10.12688/f1000research.10137.1>`__.
-
-For citing the actual code, we recommend looking at our Zenodo entry.
-You will find a variety of citation styles and ways to export it at
-|DOI|.
 
 How do I get more space inside my CWL tool running in a container?
 ------------------------------------------------------------------
@@ -133,6 +322,7 @@ Also be aware that some tools will use space from your root filesystem.
 For example, Docker's storage driver and data volumes will by default
 install to and use space on your root filesystem.
 
+
 Do you have tips on creating Dockerfiles?
 -----------------------------------------
 
@@ -144,6 +334,7 @@ Do you have tips on creating Dockerfiles?
 -  do not depend on changes to ``hostname`` or ``/etc/hosts``, Docker
    will interfere with this
 -  try to keep your Docker images small
+
 
 Do you have tips on creating CWL files?
 ---------------------------------------
@@ -178,99 +369,6 @@ Additionally:
       your container. Make sure your host running Docker has sufficient
       scratch space for processing your genomics data.
 
-.. _how-do-i-use-the-dockstore-cli-on-a-mac:
-
-How do I use the Dockstore CLI on a Mac?
-----------------------------------------
-
-See `Docker for Mac <https://docs.docker.com/engine/installation/mac/>`__ for installation information.
-
-.. note:: Docker behaves a bit differently on a
-    `Mac <https://docs.docker.com/docker-for-mac/osxfs/#/namespaces>`__ than
-    on a typical Ubuntu machine. By default the only shared volumes are
-    /Users, /Volumes, /tmp, and /private. Note that /var is not a shared
-    directory (and can't be set as one). ``cwltool`` uses your TMPDIR (the
-    env variable) to setup volumes with docker, which on a Mac can default
-    to a subdirectory of /var. In order to get ``cwltool`` working on your
-    Mac, you need to set your TMPDIR to be under one of the shared volumes
-    in Docker for Mac. You can do this by doing something similar to the
-    following:
-    ::
-
-        export TMPDIR=/tmp/docker_tmp
-
-By default, Docker for Mac allocates fewer resources (CPU, Memory, Swap)
-to containers compared to what is available on your host machine. You
-can change what it allocates using the Docker for Mac GUI under
-``Preferences > Advanced`` as described
-`here <https://docs.docker.com/docker-for-mac/#advanced>`__.
-
-* The default allocation can cause workflows or tools to fail without informing the user with a memory or resource related error message. If you find that your workflow or tool is behaving differently on a Mac compared to a similarly resourced Ubuntu environment, you can try increasing the resources allocated to Docker on the Mac to resolve the discrepancy.
-
-.. _what-is-a-verified-tool-or-workflow:
-
-What is a verified tool or workflow?
-------------------------------------
-
-A verified tool/workflow means that at least one version has been verified to be successfully ran on a platform.
-
-See :doc:`/advanced-topics/verification` for full details on this feature.
-
-What is a default version of a tool or workflow?
-------------------------------------------------
-
-Every tool/workflow is recommended to have a default version set by its
-author. It indicates to the end users which version of the tool/workflow
-they should use. For tools, the default version is uniquely identified
-by the tag from the Docker image repository. For workflows, the default
-version is identified by the Git Reference (which could be a Git tag or
-a Git branch). The default version can be set in the 'Versions' tab of a
-tool/workflow via radio buttons.
-
-Setting the default version affects a number of elements including (but
-not limited to):
-
-1. It determines what is displayed in the 'Description' section of the
-   'Info' Tab
-2. It is the first version other end users see when no version is
-   specified. For example
-   https://dockstore.org/containers/quay.io/pancancer/pcawg-bwa-mem-workflow
-   is redirected to
-   https://dockstore.org/containers/quay.io/pancancer/pcawg-bwa-mem-workflow:develop?tab=info
-3. It is the version of the tool/workflow that is launched by default
-   when users launch a tool/workflow from the Dockstore CLI.
-   For example, if version 1.0 is set as the default version of the
-   quay.io/cancercollaboratory/dockstore-tool-bedgraph-bigwig tool,
-
-    ``$ dockstore tool launch --entry quay.io/cancercollaboratory/dockstore-tool-bedgraph-bigwig:1.0 --json Dockstore.json`` 
-    
-    would be equivalent to
-
-    ``$ dockstore tool launch --entry quay.io/cancercollaboratory/dockstore-tool-bedgraph-bigwig --json Dockstore.json``
-4. The docker pull command in the tools search reflects the defaultversion
-
-How can I use the Dockstore CLI with Python 2?
-----------------------------------------------
-
-Python 2 support ended in 2020. You can get the Python 2 requirements.txt with ``curl -o requirements.txt "https://dockstore.org/api/metadata/runner_dependencies?python_version=2"``
-but it is currently untested.
-
-How do I add other users as maintainers of a workflow?
-------------------------------------------------------
-
-For workflows registered with GitHub, Dockstore allows users from the same GitHub organization to manage workflows
-together. If a new GitHub workflow from the same GitHub organization is added to Dockstore by another user, click
-the "Discover Existing Dockstore Workflows" button in the "My Workflows" menu so the workflow will appear in My Workflows.
-
-.. image:: discover_existing_workflows_screenshot.png
-
-If the workflow was added by manually registering it, click Refresh Organization.
-
-For participants of the :doc:`limited sharing
-beta </advanced-topics/sharing-workflows/>`, you can enter the email
-addresses of the users you wish to share with to give them permissions
-to your workflow. This is only available for hosted workflows and users
-with Google accounts linked to Terra.
 
 .. _why-would-i-want-to-add-a-specific-version-of-a-workflow-to-a-collection:
 
@@ -284,69 +382,6 @@ As an example, if your organization is responsible for a workflow and its mainte
 Note that the version of a workflow can be especially important when working with launch-with partners. Some partners will take into account the version of the workflow that you are on wheras other partners will give the option of or require selecting the workflow version when performing a workflow launch. For example, Terra will automatically bring up the version you are currently browsing when performing a launch although you will have an option to override later in the process. 
 
 In summary: you can pin either a specific version of a workflow or a workflow in general depending on what relationship you wish to express. We recommend explaining further for others in the accompanying Markdown description. 
-
-
-Why are my workflows from an organization I belong to not visible?
-------------------------------------------------------------------
-
-Organizations have the ability to restrict access to the API for third
-party applications. GitHub provides a
-`tutorial <https://help.github.com/en/articles/enabling-oauth-app-access-restrictions-for-your-organization/>`__
-on how to add these restrictions to your organizations.
-
-In order for Dockstore to gain access to organizations of this type, you
-will need to grant access to the Dockstore application. Dockstore will
-only be reading information on workflows in your organization and who
-has access to them in order to mirror these restrictions on Dockstore
-itself. GitHub provides a
-`tutorial <https://help.github.com/en/articles/approving-oauth-apps-for-your-organization/>`__
-for approving third party apps access to your organization.
-
-What is the difference between logging in with GitHub or logging in with Google?
---------------------------------------------------------------------------------
-
-The intent here is that you should be able to login with either login
-method and still conveniently get into the same Dockstore account. With
-login via Google, if you are a Terra user you will also have access to
-:doc:`sharing functionality </advanced-topics/sharing-workflows>`.
-
-Note that for simplicity, each of your GitHub or Google accounts can
-only be associated with one account at a time. You will need to link
-with a different account for each login method or delete your account if
-you want to assign them to a new Dockstore account.
-
-How do I launch tools/workflows without internet access on compute nodes?
--------------------------------------------------------------------------
-
-Some tools/workflows require Docker images to launch even if they are
-local entries. If the compute nodes do not have internet access, you can
-follow these steps:
-
-1. download the Docker image(s) on the head node which does have internet access using the ``docker save -o <filename> <imagename>``
-2. ensure that the ``<imagename>`` matches the image name specific in the CWL or WDL descriptor 
-3. place the image file(s) in a location that the compute nodes have access to (make sure there are only images in that directory)
-4. specify in the dockstore config file (default ~/.dockstore/config) the directory that contains your image(s) using ``docker-images = /home/user/docker_images_directory``
-
-The Dockstore CLI will automatically load all Docker images in the
-directory specified prior to a ``launch --local-entry`` command
-
-How do I send private messages to administrators or report security vulnerabilities?
-------------------------------------------------------------------------------------
-
-Users are able to open helpdesk tickets on `Discourse <https://discuss.dockstore.org/>`_. Users can create helpdesk tickets in
-case of privacy complaints, security vulnerabilities, or any other urgent matter related to Dockstore. Helpdesk tickets will be addressed
-by Dockstore administrators.
-
-The following steps can be taken to create a helpdesk ticket (also shown `here <https://discuss.dockstore.org/t/opening-helpdesk-tickets/1506>`_).
-
-1. Navigate to `Discourse <https://discuss.dockstore.org/>`_ and login.
-2. Select your profile icon, located in the top right corner of the screen.
-3. Select the ``mail`` icon, located in the dropdown.
-4. Send a message to the ``dockstore_admins`` group.
-
-.. Note:: If you are unable to see a ``New Message`` button on the mail page, you may be considered a new user and have insufficient privileges. \
-   Entering 5 topics and viewing 30 posts over a minimum of 10 minutes will raise your privileges. \
-   You will be notified of any privilege changes to your account via the mailbox.
 
 
 Any last tips on using Dockstore?

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,13 +1,8 @@
 FAQ
 ===
 
-Contents:
-
-- :ref:`General Dockstore Questions <faq-header-general-dockstore-questions>`
-- :ref:`Dockstore CLI <faq-header-dockstore-cli>`
-- :ref:`GitHub Integration <faq-header-github-integration>`
-- :ref:`Permissions <faq-header-permissions>`
-- :ref:`Miscellaneous <faq-header-other>`
+.. contents:: Table of Contents
+  :local:
 
 .. _faq-header-general-dockstore-questions:
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,6 +1,16 @@
 FAQ
 ===
 
+Contents:
+
+- :ref:`General Dockstore Questions <faq-header-general-dockstore-questions>`
+- :ref:`Dockstore CLI <faq-header-dockstore-cli>`
+- :ref:`GitHub Integration <faq-header-github-integration>`
+- :ref:`Permissions <faq-header-permissions>`
+- :ref:`Miscellaneous <faq-header-other>`
+
+.. _faq-header-general-dockstore-questions:
+
 General Dockstore Questions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -59,13 +69,6 @@ not limited to):
     ``$ dockstore tool launch --entry quay.io/cancercollaboratory/dockstore-tool-bedgraph-bigwig --json Dockstore.json``
 4. The docker pull command in the tools search reflects the defaultversion
 
-How can I use the Dockstore CLI with Python 2?
-----------------------------------------------
-
-Python 2 support ended in 2020. You can get the Python 2 requirements.txt with ``curl -o requirements.txt "https://dockstore.org/api/metadata/runner_dependencies?python_version=2"``
-but it is currently untested.
-
-
 
 How do I send private messages to administrators or report security vulnerabilities?
 ------------------------------------------------------------------------------------
@@ -95,6 +98,9 @@ paper <http://dx.doi.org/10.12688/f1000research.10137.1>`__.
 For citing the actual code, we recommend looking at our Zenodo entry.
 You will find a variety of citation styles and ways to export it at
 |DOI|.
+
+
+.. _faq-header-dockstore-cli:
 
 Dockstore CLI
 ^^^^^^^^^^^^^
@@ -145,6 +151,13 @@ can change what it allocates using the Docker for Mac GUI under
 * The default allocation can cause workflows or tools to fail without informing the user with a memory or resource related error message. If you find that your workflow or tool is behaving differently on a Mac compared to a similarly resourced Ubuntu environment, you can try increasing the resources allocated to Docker on the Mac to resolve the discrepancy.
 
 
+How can I use the Dockstore CLI with Python 2?
+----------------------------------------------
+
+Python 2 support ended in 2020. You can get the Python 2 requirements.txt with ``curl -o requirements.txt "https://dockstore.org/api/metadata/runner_dependencies?python_version=2"``
+but it is currently untested.
+
+
 The CLI is failing with Java 8
 ------------------------------
 
@@ -177,6 +190,7 @@ The Dockstore CLI will automatically load all Docker images in the
 directory specified prior to a ``launch --local-entry`` command
 
 
+.. _faq-header-github-integration:
 
 Integration with GitHub
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -214,7 +228,7 @@ your account in the future, do not reuse the original name of the renamed
 repository. If you do, redirects to the renamed repository will break.
 
 
-
+.. _faq-header-permissions:
 
 Permissions
 ^^^^^^^^^^^^
@@ -254,6 +268,7 @@ itself. GitHub provides a
 for approving third party apps access to your organization.
 
 
+.. _faq-header-other:
 
 Other
 ^^^^^

--- a/docs/getting-started/getting-started-with-galaxy.rst
+++ b/docs/getting-started/getting-started-with-galaxy.rst
@@ -22,7 +22,7 @@ Galaxy is a web-based platform for data analysis. Galaxy is open source and can 
 Using Existing Galaxy Servers
 -----------------------------
 
-Institutions across the world maintain Galaxy instances that are shared with the greater community and are a great way to learn and use Galaxy. Some of these instances are subsidized by grants and offered for free (such as the `Galaxy US <https://usegalaxy.org/>`__, `Galaxy EU <https://usegalaxy.eu/>`__, and `Galaxy AU <https://usegalaxy.org.au/>`__) and some are available for a fee (such as `Galaxy AnVIL <https://anvil.terra.bio/>`__ or `Galaxy Pro <https://researcher.galaxyworks.io/>`__). A lot of great learning resources are available on the the `Galaxy Training Network <https://training.galaxyproject.org/>`__, with help on specific questions available via `Galaxy Help <https://help.galaxyproject.org/>`__.
+Institutions across the world maintain Galaxy instances that are shared with the greater community and are a great way to learn and use Galaxy. Some of these instances are subsidized by grants and offered for free (such as the `Galaxy US <https://usegalaxy.org/>`__, `Galaxy EU <https://usegalaxy.eu/>`__, and `Galaxy AU <https://usegalaxy.org.au/>`__) and some are available for a fee (such as `Galaxy AnVIL <https://anvil.terra.bio/>`__). A lot of great learning resources are available on the the `Galaxy Training Network <https://training.galaxyproject.org/>`__, with help on specific questions available via `Galaxy Help <https://help.galaxyproject.org/>`__.
 
 Using Custom Galaxy in the Cloud with Terra, and AnVIL
 ------------------------------------------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
-myst-parser
-sphinx_rtd_theme
+sphinx==4.4.0
+myst-parser==0.16.1
+sphinx_rtd_theme==1.0.0
 git+https://github.com/pdavide/sphinxcontrib-discourse


### PR DESCRIPTION
I was trying to figure out what information does and does not belong on our FAQ page and realized I was struggling to keep track of the FAQ page as it currently exists. So, I made a version that divides it into sections. There are other changes I'm playing around with, but I want to propose this one first. I made sure to keep questions that have an `.._internal-identifier`, such as the one on verified workflows, together with that identifier, and added identifiers for the sections to create a bogus TOC (bogus in that it won't get double-indexed on the sidebar).

Would like some feedback for categories. I don't like the current miscellaneous one that I have, feels kind of like a cop out. Would also like feedback r/e having all questions on the top of the page instead of just the categories, which would probably be most efficient to do via the actual TOC command (there is a workaround to keep it from overtaking the sidebar, I believe, but apparently it's a bit finicky).