### PR TITLE
Fix bullet points on develop

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 sphinx==4.4.0
 myst-parser==0.16.1
-sphinx_rtd_theme==0.4.3
+sphinx_rtd_theme==1.0.0
 git+https://github.com/pdavide/sphinxcontrib-discourse


### PR DESCRIPTION
The last commit pinned the following versions to requirements.txt

> sphinx==4.4.0
> myst-parser==0.16.1
> sphinx_rtd_theme==0.4.3
> git+https://github.com/pdavide/sphinxcontrib-discourse

This combination results in bullet points disappearing, see [#4724](https://github.com/dockstore/dockstore/issues/4724). Updating to sphinx_rtd_theme 1.0.0 brings them back. 

I decided not to update myst-parser as the current version (0.17.something) breaks the inline URLs on docker_instructions.md; they still work as expected on 0.16.1