### PR TITLE
Fix news section

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,6 +21,7 @@ going straight to the :doc:`End User Topics <end-user-topics/end-user-topics>` o
    :maxdepth: 1
 
    dockstore-introduction
+   news
 
 .. toctree::
    :caption: Getting Started (Tutorial)
@@ -135,16 +136,6 @@ going straight to the :doc:`End User Topics <end-user-topics/end-user-topics>` o
    :maxdepth: 1
 
    changelog
-
-.. toctree::
-   :caption: News and Events
-   :maxdepth: 1
-   :glob:
-   :titlesonly:
-   :reversed:
-
-   news
-   news/*
 
 .. toctree::
    :caption: System Status

--- a/docs/news.rst
+++ b/docs/news.rst
@@ -6,3 +6,12 @@ news and events related to Dockstore. The items are
 listed in chronological order.
 
 .. (RSS was previously provided by github pages) The feed is also available through `RSS <https://docs.dockstore.org/feed.xml>`__. 
+
+.. toctree::
+   :caption: News and Events
+   :maxdepth: 1
+   :glob:
+   :titlesonly:
+   :reversed:
+
+   news/*


### PR DESCRIPTION
https://github.com/dockstore/dockstore/issues/4747

* Moves "news and events" to the "about" section on the sidebar and front page TOC
* TOC for news items is now generated by "news and events" RST, will only show in sidebar as dropdown when "news and events" is selected
* "News and events" page isn't blank