### PR TITLE
Add Amazon ECR to Docker image checksum documentation

### DIFF
--- a/docs/_static/checksum-support.html
+++ b/docs/_static/checksum-support.html
@@ -27,13 +27,13 @@
         <tr style="border-top: 1px solid #ddd;">
             <th style="padding: 5px; font-weight: normal;">Tool (non-hosted)</th>
             <th style="padding: 5px; font-weight: normal;">CWL, WDL</th>
-            <th style="padding: 5px; font-weight: normal;">Quay.io, Docker Hub, GitLab</th>
+            <th style="padding: 5px; font-weight: normal;">Quay.io, Docker Hub, Amazon ECR, GitLab</th>
             <th style="padding: 5px; font-weight: normal;">Refresh</th>
         </tr>
         <tr style="border-top: 1px solid #ddd;">
             <th style="padding: 5px; font-weight: normal;">Workflow</th>
             <th style="padding: 5px; font-weight: normal;">CWL, WDL, Nextflow</th>
-            <th style="padding: 5px; font-weight: normal;">Quay.io, Docker Hub</th>
+            <th style="padding: 5px; font-weight: normal;">Quay.io, Docker Hub, Amazon ECR</th>
             <th style="padding: 5px; font-weight: normal;">Snapshot</th>
         </tr>
     </body>

--- a/docs/_static/checksum-support.html
+++ b/docs/_static/checksum-support.html
@@ -36,5 +36,11 @@
             <th style="padding: 5px; font-weight: normal;">Quay.io, Docker Hub, Amazon ECR</th>
             <th style="padding: 5px; font-weight: normal;">Snapshot</th>
         </tr>
+        <tr style="border-top: 1px solid #ddd;">
+            <th style="padding: 5px; font-weight: normal;">GitHub App Tool</th>
+            <th style="padding: 5px; font-weight: normal;">CWL</th>
+            <th style="padding: 5px; font-weight: normal;">Quay.io, Docker Hub, Amazon ECR</th>
+            <th style="padding: 5px; font-weight: normal;">Snapshot</th>
+        </tr>
     </body>
 </table>

--- a/docs/advanced-topics/checksum-support.rst
+++ b/docs/advanced-topics/checksum-support.rst
@@ -97,9 +97,9 @@ As noted in the table above, Docker image checksums are grabbed on refresh and s
 Amazon ECR, or GitLab. It's also important to note that this is done for the Docker image registered on the tool through Dockstore and not necessarily
 the one included within the descriptor file itself.
 
-Workflows
----------
-For workflows, Docker image checksums are grabbed on snapshot. However, the Docker images we can retrieve from descriptor files
+Workflows and GitHub App Tools
+------------------------------
+For workflows and GitHub App tools, Docker image checksums are grabbed on snapshot. However, the Docker images we can retrieve from descriptor files
 are more limited compared to the other checksum support covered so far. Although we can generally provide checksum info for referenced Docker
 images for CWL, WDL, and NFL, there are some caveats. Most conditions are language specific, but for all workflow languages, the images
 referenced must be from Quay.io, Docker Hub, or Amazon ECR and they must include a version. The following are the known constraints for each language.

--- a/docs/advanced-topics/checksum-support.rst
+++ b/docs/advanced-topics/checksum-support.rst
@@ -71,7 +71,7 @@ Descriptions for the two endpoints of note are as follows:
 
 Just like the file endpoints, the id parameter used in the endpoints above can be found on an entry's public page; underneath the Info tab, look for the bolded words **TRS**.
 
-To verify a checksum as reported by the Dockstore API matches what you download from the Docker registry first find the checksum
+To verify if a checksum as reported by the Dockstore API matches what you download from the Docker registry, first find the checksum
 and image path using one of the above methods for the image you would like to verify. Then download the image using the
 Docker CLI client.
 
@@ -79,7 +79,7 @@ Docker CLI client.
 
     docker pull quay.io/briandoconnor/dockstore-tool-md5sum:1.0.4
 
-When the download has completed a Digest is provided in the terminal output. This should match the checksum provided
+When the download has completed, a Digest is provided in the terminal output. This should match the checksum provided
 by the Dockstore API.
 
 Verifying the image checksum can give you better guarantees the image has not changed since the workflow was published to Dockstore.
@@ -94,15 +94,15 @@ or `Azure <https://docs.microsoft.com/en-us/azure/container-registry/container-r
 Tools
 -----
 As noted in the table above, Docker image checksums are grabbed on refresh and should work as long as the image is from Quay.io, Docker Hub,
-or GitLab. It's also important to note that this is done for the Docker image registered on the tool through Dockstore and not necessarily
+Amazon ECR, or GitLab. It's also important to note that this is done for the Docker image registered on the tool through Dockstore and not necessarily
 the one included within the descriptor file itself.
 
 Workflows
 ---------
 For workflows, Docker image checksums are grabbed on snapshot. However, the Docker images we can retrieve from descriptor files
 are more limited compared to the other checksum support covered so far. Although we can generally provide checksum info for referenced Docker
-images for CWL, WDL, and NFL, there are some caveats. Most conditions are language specific, but for all workflow langagues, the images
-referenced must be from Quay.io or Docker Hub and they must include a version. The following are the known constraints for each language.
+images for CWL, WDL, and NFL, there are some caveats. Most conditions are language specific, but for all workflow languages, the images
+referenced must be from Quay.io, Docker Hub, or Amazon ECR and they must include a version. The following are the known constraints for each language.
 
 .. There is a ticket to expand on when we are not able to parse the docker images. This is only what I'm fairly sure about...
 

--- a/docs/advanced-topics/checksum-support.rst
+++ b/docs/advanced-topics/checksum-support.rst
@@ -79,7 +79,7 @@ Docker CLI client.
 
     docker pull quay.io/briandoconnor/dockstore-tool-md5sum:1.0.4
 
-When the download has completed, a Digest is provided in the terminal output. This should match the checksum provided
+When the download has completed, a digest is provided in the terminal output. This should match the checksum provided
 by the Dockstore API.
 
 Verifying the image checksum can give you better guarantees the image has not changed since the workflow was published to Dockstore.
@@ -95,7 +95,7 @@ Tools
 -----
 As noted in the table above, Docker image checksums are grabbed on refresh and should work as long as the image is from Quay.io, Docker Hub,
 Amazon ECR, or GitLab. It's also important to note that this is done for the Docker image registered on the tool through Dockstore and not necessarily
-the one included within the descriptor file itself.
+the one referenced within the descriptor file itself.
 
 Workflows and GitHub App Tools
 ------------------------------


### PR DESCRIPTION
For https://github.com/dockstore/dockstore/issues/4345

Updated docs to add that Amazon ECR checksum harvesting is supported for tools and workflows. Also added a row for GitHub App tools which behaves like workflows for Docker image checksum harvesting

Is develop the correct branch for 1.12 work?