### PR TITLE
Skip all doi.org URLs in linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -52,7 +52,8 @@ linkcheck_ignore = [
     'https://software.broadinstitute.org/firecloud/',
     'https://support.orcid.org/hc/en-us/articles/360006894754-Edit-works',
     'launch-with/anvil-launch-with.html', 'launch-with/cavatica-launch-with.html', 'launch-with/dnanexus-launch-with.html', 'launch-with/cgc-launch-with.html',
-    'launch-with/galaxy-launch-with.html', 'launch-with/nextflow-tower-launch-with.html', 'launch-with/terra-launch-with.html'	
+    'launch-with/galaxy-launch-with.html', 'launch-with/nextflow-tower-launch-with.html', 'launch-with/terra-launch-with.html',
+    'https://doi.org/*'
     ]
 
 


### PR DESCRIPTION
These URLs appear to redirect to a different URL, but linkcheck should be able to handle that. No idea why that's happening but this workaround handles it. I don't like it, but there is already a doi.org URL getting skipped, so maybe this sort of thing has happened before?