### PR TITLE
Remove redundancies

### DIFF
--- a/docs/getting-started/dockstore-tools.rst
+++ b/docs/getting-started/dockstore-tools.rst
@@ -38,8 +38,6 @@ to the legacy methods described below.
 
 Register Your Tool to Automatically Sync with GitHub (Recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. include:: /getting-started/github-apps/note--registration.rst
-
 Dockstore has added GitHub App support for registering tools. Using GitHub Apps, Dockstore can react to changes on GitHub as they are made,
 keeping Dockstore synced with GitHub automatically. You can read more about it :doc:`in our docs about the Dockstore GitHub App </getting-started/github-apps/github-apps>`, but a summary is present below.
 

--- a/docs/getting-started/dockstore-tools.rst
+++ b/docs/getting-started/dockstore-tools.rst
@@ -80,8 +80,6 @@ For more information on this method, as well as general troubleshooting advice, 
 Legacy Tool Registration
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. important:: The following methods are NOT recommended and should only be used if your tool descriptor files are registered on BitBucket or GitLab.
-
 .. include:: /getting-started/github-apps/note--legacy-dont-sync.rst
 
 If you are using BitBucket or GitLab and would prefer not to use GitHub, or if you are using GitHub but do not wish to install our app, our legacy registration methods have you covered. Several options are available to you and described in our :doc:`legacy registration methods documentation </advanced-topics/legacy/tool-legacy-registration>`.


### PR DESCRIPTION
Feeling compassionate on my birthday so I will not make all of my hotfixes into one mega PR this time.

This one just removes some redundancies. dockstore-tools.rst does not need note--registration.rst twice, and note--legacy-dont-sync.rst already states that legacy methods are not recommended so we needn't say it immediately prior.