### PR TITLE
Make need for add'l commit after adding .dockstore.yml explicit + clearer

### DIFF
--- a/docs/getting-started/dockstore-tools.rst
+++ b/docs/getting-started/dockstore-tools.rst
@@ -75,6 +75,8 @@ Now that your tool has been added, any time there is a push to a branch on GitHu
 it is automatically updated on Dockstore! Anytime there is a deletion of a branch on GitHub that has a .dockstore.yml, the version is
 removed from Dockstore.
 
+.. include:: /getting-started/github-apps/note--addl-commit.rst
+
 For more information on this method, as well as general troubleshooting advice, please check our :doc:`Dockstore GitHub Apps Overview </getting-started/github-apps/github-apps>` page.
 
 Legacy Tool Registration

--- a/docs/getting-started/dockstore-workflows.rst
+++ b/docs/getting-started/dockstore-workflows.rst
@@ -71,6 +71,8 @@ Now that your workflow has been added, any time there is a push to a branch on G
 it is automatically updated on Dockstore! Anytime there is a deletion of a branch on GitHub that has a .dockstore.yml, the version is
 removed from Dockstore.
 
+.. include:: /getting-started/github-apps/note--addl-commit.rst
+
 For more information on this method, as well as general troubleshooting advice, please check our :doc:`Dockstore GitHub Apps Overview </getting-started/github-apps/github-apps>` page.
 
 Legacy Registration Methods

--- a/docs/getting-started/github-apps/github-apps-troubleshooting-tips.rst
+++ b/docs/getting-started/github-apps/github-apps-troubleshooting-tips.rst
@@ -70,9 +70,9 @@ The changes made to my GitHub repo aren't appearing on Dockstore, but I've alrea
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 The general troubleshooting flow we recommend is the following:
 
+- Push another commit after adding the correct repository to activate the sync to Dockstore. (That is, make a push *after* the .dockstore.yml file has been pushed, and on the same branch that the .dockstore.yml exists on.)
 - Try waiting a couple of minutes and refreshing the browser on the My Workflows/My Tools page again. Sometimes, GitHub takes a few minutes to send Dockstore the changes made to a repository.
 - Verify that the GitHub app was given access to the right repository or organization. 
-- If access was given to the wrong organization or repository, or this is your first time installing the app, you'll need to push another commit after adding the correct repository to activate the sync to Dockstore.
 - Double check the .dockstore.yml file.
 
     - Is it in the root directory?

--- a/docs/getting-started/github-apps/note--addl-commit.rst
+++ b/docs/getting-started/github-apps/note--addl-commit.rst
@@ -1,3 +1,2 @@
 .. note::
-
-Once the GitHub App is installed and a .dockstore.yml is present, please make sure to push one *additional* commit to your repository *after* the commit that adds the .dockstore.yml file. This helps make sure your workflows, tools, and services show up in Dockstore.
+	Once the GitHub App is installed and a .dockstore.yml is present, please make sure to push one *additional* commit to your repository *after* the commit that adds the .dockstore.yml file. This helps make sure your workflows, tools, and services show up in Dockstore.

--- a/docs/getting-started/github-apps/note--addl-commit.rst
+++ b/docs/getting-started/github-apps/note--addl-commit.rst
@@ -1,0 +1,3 @@
+.. note::
+
+Once the GitHub App is installed and a .dockstore.yml is present, please make sure to push one *additional* commit to your repository *after* the commit that adds the .dockstore.yml file. This helps make sure your workflows, tools, and services show up in Dockstore.

--- a/docs/getting-started/github-apps/note--gha-summary.rst
+++ b/docs/getting-started/github-apps/note--gha-summary.rst
@@ -2,8 +2,8 @@
   Summary of GitHub App usage:
 
   #. :doc:`Install Dockstore GitHub App </getting-started/github-apps/snippet--installation>`
-  #. Put a valid .dockstore.yml file into the top level of your repository
-  #. Push a new commit with a .dockstore.yml file present
+  #. Commit a valid .dockstore.yml file into the top level of your repository
+  #. Push an additional commit onto the branch that has the .dockstore.yml file present
   #. Wait up to 5 minutes for Dockstore to process the new version
   #. See workflow on Dockstore
 

--- a/docs/getting-started/github-apps/snippet--installation.rst
+++ b/docs/getting-started/github-apps/snippet--installation.rst
@@ -42,9 +42,3 @@ If you are adding the GitHub App to an organization for which you are not an adm
     - :doc:`Automatic Syncing with GitHub Apps and .dockstore.yml </getting-started/github-apps/github-apps/>` - details on writing a .dockstore.yml file
     - :doc:`Migrating Your Existing Workflows </getting-started/github-apps/migrating-workflows-to-github-apps>` - a tutorial on converting already registered workflows
     - :doc:`Troubleshooting and FAQ </getting-started/github-apps/github-apps-troubleshooting-tips>` - tips on resolving Dockstore Github App issues.
-
-Ensuring sychronization
-~~~~~~~~~~~~~~~~~~~~~~~
-
-Once the GitHub App is installed and a .dockstore.yml is present, please make sure to push one *additional* commit to your repository. This helps make sure your workflows, tools, and services show up in Dockstore.
-


### PR DESCRIPTION
Every time you create a new .dockstore.yml file to add a new repo to Dockstore, you must make one additional commit to the repo *after* the .dockstore.yml is committed, or else your wf/tool/service will not show up. Despite what some of our older docs implied, this is the case even if you previously gave the GitHub app access to all repositories and/or already have a GitHub app wf/tool/service on Dockstore for that same organization/user.