### PR TITLE
New PR on hotfix branch: Simplify registering tools

### DIFF
--- a/docs/getting-started/dockstore-tools.rst
+++ b/docs/getting-started/dockstore-tools.rst
@@ -77,7 +77,7 @@ Legacy Tool Registration
 
 .. include:: /getting-started/github-apps/note--legacy-dont-sync.rst
 
-If you are using BitBucket or GitLab and would prefer not to use GitHub, or if you are using GitHub but do not wish to install our app, our legacy registration methods have you covered. Several options are available to you and described in our :doc:`legacy registration methods documentation </advanced-topics/legacy/tool-legacy-registration>`.
+If you are using BitBucket or GitLab and would prefer not to use GitHub, or if you are using GitHub but do not wish to install our app, our legacy registration methods have you covered. Several options are available to you and described in our :doc:`legacy registration methods documentation </advanced-topics/legacy/tool-legacy-registration>`. If you must use the legacy tool registration methods, then you may want to read :doc:`how our definition of tool is different for these legacy methods </../advanced-topics/dockstore-tools-overhaul>`.
 
 Sharing Your Tool
 -----------------

--- a/docs/getting-started/dockstore-tools.rst
+++ b/docs/getting-started/dockstore-tools.rst
@@ -34,7 +34,7 @@ Register Your Tool to Automatically Sync with GitHub (Recommended)
 .. include:: /getting-started/github-apps/note--registration.rst
 
 Using GitHub Apps, Dockstore can react to changes on GitHub as they are made,
-keeping Dockstore synced with GitHub automatically. You can learn more :doc:`in our Dockstore GitHub App </getting-started/github-apps/github-apps> doc`.
+keeping Dockstore synced with GitHub automatically. You can learn more :doc:`in our Dockstore GitHub App </getting-started/github-apps/github-apps>` doc.
 
 .. include:: /getting-started/github-apps/snippet--installation.rst
 

--- a/docs/getting-started/dockstore-tools.rst
+++ b/docs/getting-started/dockstore-tools.rst
@@ -15,9 +15,9 @@ Assumptions
 -----------
 This document assumes you already have a tool ready to register. 
 
-If you followed :doc:`Getting Started With CWL </getting-started/getting-started-with-cwl>` to create a CWL tool, you will now have your ``Dockerfile`` and ``Dockstore.cwl`` in GitHub, have setup Quay.io to automatically build your Docker image, and have linked your accounts to Dockstore. This will allow you to use any of our registration methods, including legacy methods. You can also follow this tutorial if your tool is not associated with an autobuilding Docker image.
+If you followed :doc:`Getting Started With CWL </getting-started/getting-started-with-cwl>` to create a CWL tool, you will now have a ``Dockstore.cwl`` in GitHub and have linked your accounts to Dockstore. This will allow you to use the Dockstore GitHub App to register your tool. Of course, you can always follow along with your own unique tools too. Regardless of how you made your tool, this tutorial will assume you are using CWL. For all other languages, :doc:`you will want to register a workflow </getting-started/dockstore-workflows>`.
 
-.. note:: Dockstore allows the registration of "WDL tools" using legacy registration methods. The WDL community does not explicitly differentiate :doc:`tools versus workflows </getting-started/intro-to-dockstore-tools-and-workflows>`. We encourage people to :doc:`register WDLs as workflows </getting-started/dockstore-workflows>` instead.
+.. note:: Dockstore allows the registration of "WDL tools" using legacy registration methods. However, the WDL community does not explicitly differentiate :doc:`tools versus workflows </getting-started/intro-to-dockstore-tools-and-workflows>`. We encourage people to :doc:`register WDLs as workflows </getting-started/dockstore-workflows>` instead.
 
 Register Your Tool in Dockstore
 -------------------------------

--- a/docs/getting-started/dockstore-tools.rst
+++ b/docs/getting-started/dockstore-tools.rst
@@ -13,26 +13,19 @@ Tutorial Goals
 
 Assumptions
 -----------
-This document assumes you have already have a tool ready to register. You do not need to have a Dockerfile associated with it unless you are using one our legacy registration methods (more on that below).
+This document assumes you already have a tool ready to register. 
 
-If you followed :doc:`Getting Started With CWL </getting-started/getting-started-with-cwl>` to create a CWL tool, you will now have your ``Dockerfile`` and ``Dockstore.cwl`` in GitHub, have setup Quay.io to automatically build your Docker image, and have linked your accounts to Dockstore. This will allow you to use any of our registration methods, including legacy methods. Of course, you can always follow along with your own unique tools too, which may or may not be associated with an autobuilding Docker image.
+If you followed :doc:`Getting Started With CWL </getting-started/getting-started-with-cwl>` to create a CWL tool, you will now have your ``Dockerfile`` and ``Dockstore.cwl`` in GitHub, have setup Quay.io to automatically build your Docker image, and have linked your accounts to Dockstore. This will allow you to use any of our registration methods, including legacy methods. You can also follow this tutorial if your tool is not associated with an autobuilding Docker image.
 
-Regardless of how you made your tool, this tutorial will assume you are using CWL. For all other languages, :doc:`please see our documentation on workflows instead </getting-started/dockstore-workflows>`.
-
-.. note:: The WDL community does not explicitly differentiate :doc:`tools versus workflows </getting-started/intro-to-dockstore-tools-and-workflows>`. However, Dockstore allows the registration of "WDL tools" using legacy registration methods. We encourage people to :doc:`register WDLs as workflows </getting-started/dockstore-workflows>` instead.
+.. note:: Dockstore allows the registration of "WDL tools" using legacy registration methods. The WDL community does not explicitly differentiate :doc:`tools versus workflows </getting-started/intro-to-dockstore-tools-and-workflows>`. We encourage people to :doc:`register WDLs as workflows </getting-started/dockstore-workflows>` instead.
 
 Register Your Tool in Dockstore
 -------------------------------
 .. include:: /getting-started/github-apps/note--registration.rst
 
-There are a variety of ways to get your tools into Dockstore. Users can either use GitHub App registration or our legacy registration methods.
-GitHub App registration is the recommended way to register all new tools on Dockstore. GitHub App tools and tools registered using our other methods (legacy tools) are
-very different from one another. Use the following questions to determine which method to use:
+We recommend users register their tool with our GitHub App to benefit from GitHub's features and automatic syncing. If you do not wish to use GitHub, we do support other methods of registration in our legacy registration methods. Use the following questions to determine which registration method works for you:
 
 .. include:: /getting-started/how-to-register-work.rst
-
-If you must use the legacy tool registration methods, then you may want to read :doc:`Dockstore Tools Overhaul </../advanced-topics/dockstore-tools-overhaul>` before continuing
-to the legacy methods described below.
 
 .. _Tool Registration With GitHub Apps:
 
@@ -40,19 +33,19 @@ Register Your Tool to Automatically Sync with GitHub (Recommended)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. include:: /getting-started/github-apps/note--registration.rst
 
-Dockstore has added GitHub App support for registering tools. Using GitHub Apps, Dockstore can react to changes on GitHub as they are made,
-keeping Dockstore synced with GitHub automatically. You can read more about it :doc:`in our docs about the Dockstore GitHub App </getting-started/github-apps/github-apps>`, but a summary is present below.
+Using GitHub Apps, Dockstore can react to changes on GitHub as they are made,
+keeping Dockstore synced with GitHub automatically. You can learn more :doc:`in our Dockstore GitHub App </getting-started/github-apps/github-apps> doc`.
 
 .. include:: /getting-started/github-apps/snippet--installation.rst
 
-Once you've installed our GitHub app on a repository or organization, you'll need to add a .dockstore.yml file to
+Once GitHub app is installed on a repository or organization, you will need to add a .dockstore.yml file to
 the root directory of a branch of the repository that contains your tool. This file contains information like
 tool path, test parameter file, tool name, etc. When a push is made or a tag is created on GitHub
 with a .dockstore.yml, Dockstore will add that branch to the corresponding tool on Dockstore. If the
-tool doesn't already exist on Dockstore, one will be created (but will not automatically be published publically). Note that a single .dockstore.yml file can describe multiple tools, if all of those tools are in the same repository.
+tool doesn't already exist on Dockstore, one will be registered (but will not automatically be published publically). Note that a single .dockstore.yml file can describe multiple tools, if all of those tools are in the same repository.
 
 Below is a simple example of a .dockstore.yml file
-for an alignment tool to show you how easy it is to use. Note that all file paths in the file must be absolute.
+for an alignment tool. Note that all file paths in the file must be absolute.
 
 .. code:: yaml
 
@@ -92,23 +85,16 @@ Sharing Your Tool
 .. this section is purposely not symmetric with its equivalent in tool-legacy-registration.rst
 
 After you have successfully added your tool onto Dockstore and have it
-synced with GitHub, Bitbucket, or GitLab, you are now ready to share your
+synced with GitHub, Bitbucket, or GitLab, or hosted directly in Dockstore, you are now ready to share your
 tool with the public! Assuming that your tool has at least one valid
 version, you can publish your tool for everyone to use. Simply select the
-tool on the ``/my-tool`` page and click publish.
-
-Find Other Tools
-----------------
-
-You can find tools on the Dockstore website or also through the
-``dockstore tool search`` command line option.
+tool on the ``/my-tool`` page and click `publish`.
 
 Next Steps
 ----------
 
-You can follow this basic pattern for each of your Docker-based tools.
 Once registered, you can send links to your tools on Dockstore to
-colleagues and use it as a public platform for sharing your tools.
+colleagues and use it as a public platform for sharing your tools. 
 
 Learn about :doc:`Workflows <dockstore-workflows/>` and how they differ from tools.
 


### PR DESCRIPTION
New PR replacing #187 
- I removed a lot of information to try to simplify the getting started. If a user is publishing a tool for the first time, I don't think they need to revisit our discussion of why we changed the tool definition.
- I removed the section about searching for other tools after registering your own tool. We should separate these user personas (tool developer vs. someone searching for a tool to reuse "end user").