### PR TITLE
Pin a dependency and clarify .dockstore.yml `filter` is not about Docker tags

### DIFF
--- a/docs/assets/templates/template.rst
+++ b/docs/assets/templates/template.rst
@@ -9,6 +9,7 @@ Not sure if you are working with a workflow, a tool, or a service? :doc:`Check o
 
 Tips and tricks
 ---------------
+* This form of registration is only available to workflows, tools, and services that are hosted on GitHub
 * Make sure your file is saved as ``.dockstore.yml``, not ``dockstore.yml`` or ``.dockstore.yaml``
 * Put the .dockstore.yml file in the top of your repo or inside ``.github/``
 * The first line of a .dockstore.yml file references the version of .dockstore.yml syntax being used, not the version/tag of the workflow/tool/service it describes
@@ -17,7 +18,7 @@ Tips and tricks
 
 Examples of the filters field
 -----------------------------
-* The ``filters:`` field allows for limiting which branches and tags appear on a Dockstore entry. Regex can be used here.
+* The ``filters:`` field allows for limiting which GitHub [tags](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/managing-commits/managing-tags) and [branches](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches) appear on a Dockstore entry. Regex can be used here.
 * You can use this regex pattern to include all tags but no branches:
 
 .. code:: yaml

--- a/docs/assets/templates/template.rst
+++ b/docs/assets/templates/template.rst
@@ -18,7 +18,7 @@ Tips and tricks
 
 Examples of the filters field
 -----------------------------
-* The ``filters:`` field allows for limiting which GitHub [tags](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/managing-commits/managing-tags) and [branches](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches) appear on a Dockstore entry. Regex can be used here.
+* The ``filters:`` field allows for limiting which GitHub `tags <https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/managing-commits/managing-tags>`_ and `branches <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches>`_ appear on a Dockstore entry. Regex can be used here.
 * You can use this regex pattern to include all tags but no branches:
 
 .. code:: yaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ sphinx==4.4.0
 myst-parser==0.16.1
 sphinx_rtd_theme==1.0.0
 git+https://github.com/pdavide/sphinxcontrib-discourse
+attrs==21.4.0


### PR DESCRIPTION
Neither this version nor the old one mention Docker tags at all, but I think users new to Docker and git have a chance of getting the two mixed up. I swapped the order of the words and added "GitHub" right before "tags" in attempt to make it clearer, as well as linked GitHub's own docs on the two. Also included a sentence reminding users that they need to have their workflow/tool/service on Dockstore, just in case a user goes straight here without reading any of our other docs.