### PR TITLE
Establish a style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Dockstore Documentation
 
-Dockstore is using [Read the Docs](https://readthedocs.org/) for documentation!
+Dockstore is using [Read the Docs](https://readthedocs.org/) for documentation! Please take a look at [our style guide](./style-guide.md) to learn about our approach to documentation.
 
 Below are some tips for setting up the documentation locally and updating the code.
 

--- a/style-guide.md
+++ b/style-guide.md
@@ -76,7 +76,7 @@ See also: [Google's guidelines r/e translation](https://developers.google.com/st
 * Make sure programs/templates you are providing to the user have a way to handle non-ASCII names and names with apostrophes and hyphens
 
 ## Inclusion
-See also: [Google's guidelines for inclusive documentation](https://developers.google.com/style/inclusive-documentation).
+See also: [Google's guidelines for inclusive documentation](https://developers.google.com/style/inclusive-documentation), but be aware that some terms are still being discussed without a clear consensus at this time. The examples below demonstrate our understanding of currently recognized best practices, and may need to be adjusted over time.
 
 * Use gender-neutral language wherever possible (firefighter vs fireman)
 * Use gender-neutral pronouns when referring to a hypothetical person ("they" instead of "he or she"), even if that requires changing a verb conjugation ("they **adjust** their settings" vs "he or she **adjusts** his or her settings")

--- a/style-guide.md
+++ b/style-guide.md
@@ -44,25 +44,25 @@ See also: https://developers.google.com/style/accessibility
 * Use `.. comment` to write comments
 * Use consistent indentation spacing within a single RST file
 * Do not break up body text with a newline every x characters
-* Use use \`this style <https://example.com>\`_ of formatting external hyperlinks, as it is less error prone than the method involving setting the target in another paragraph
+* Use use \`this style \<https://example.com\>_` of formatting external hyperlinks, as it is less error prone than the method involving setting the target in another paragraph
 * Use headings in this way throughout the entire repository to avoid issues with embedding RST files into other RST files:
 
-> `page title`
+> `page title`  
 > `==========`
 > 
-> `heading level 1`
+> `heading level 1`  
 > `---------------`
 >
-> `heading level 2`
+> `heading level 2`  
 > `~~~~~~~~~~~~~~~`
 >
-> `heading level 3`
+> `heading level 3`  
 > `***************`
 >
-> `heading level 4`
+> `heading level 4`  
 > `+++++++++++++++`
 >
-> `heading level 5`
+> `heading level 5`  
 > `\``````````````
 >
  

--- a/style-guide.md
+++ b/style-guide.md
@@ -41,11 +41,14 @@ See also: [Google's guidelines for accessibility](https://developers.google.com/
 
 ## Coding in RST
 * Write in RST, not markdown
-* Use `.. comment` to write comments
+	* Archived documents orignally presented in markdown may remain in markdown
+	* Keep this style guide in markdown in order to display RST formatting
+* Use \`.. comment\` to write comments
 * Use consistent indentation spacing within a single RST file
 * Keep all sentences in a given paragraph that renders as body text on one line, i.e. do not break up body text every x characters
 * Make RST tables human-readable instead of compact -- consider using [this table generator](https://tableconvert.com/restructuredtext-generator)
 * Use \`this style \<https://example.com\>_` of formatting external hyperlinks, as it is less error prone than the method involving setting the target in another paragraph
+	* Exception: It is acceptable to use the other format to get around RST limitations about nested formatting, [as demonstrated in this commit](https://github.com/dockstore/dockstore-documentation/pull/198/commits/226410b4bd86b96e86a2dcc3045bbcfac7d04adc)
 * Use headings in this way throughout the entire repository to avoid issues with embedding RST files into other RST files:
 
 > `page title`  

--- a/style-guide.md
+++ b/style-guide.md
@@ -106,7 +106,6 @@ Adapted from: https://developers.google.com/style/tone
 	* "My Cool Workflow", etc is okay
 * Never include any humor at the expense of a person, organization, or group of people
 * You can make the case for a feature's existence, but avoid sounding too much like a salesperson
-* When describing someone doing a task, use second-person implicit whenever it makes sense to do so, but try to stick to active voice
-	* Active voice: "Click Refresh Organization to delete System 32."
-	* Passive voice: "Refresh Organization can be clicked to delete System 32."
+* When telling someone to preform a task in a tutorial, use second-person implicit whenever it makes sense to do so -- e.g., write "Click this button to delete System32" instead of "You can click this button to delete System32"
+* In general, try to avoid passive voice -- e.g., write "Click this button to delete System32" instead of "This button can be clicked to delete System32"
  

--- a/style-guide.md
+++ b/style-guide.md
@@ -113,6 +113,6 @@ Adapted from [Google's style guide r/e tone](https://developers.google.com/style
 * Never include any humor at the expense of a person, organization, or group of people
 * You can make the case for a feature's existence, but avoid sounding too much like a salesperson
 * Use [second-person](https://developers.google.com/style/person) whenever it makes sense to do so
-* When telling someone to preform a task in a tutorial or otherwise using imperatives, make the second-person subject [implicit](https://editorsmanual.com/articles/sentence-implied-subject-grammar/)
+* When telling someone to perform a task in a tutorial or otherwise using imperatives, make the second-person subject [implicit](https://editorsmanual.com/articles/sentence-implied-subject-grammar/)
 	* Example: "Click this button to delete System32" instead of "You can click this button to delete System32"
 * Use [active voice](https://developers.google.com/style/voice)

--- a/style-guide.md
+++ b/style-guide.md
@@ -79,8 +79,8 @@ See also: https://developers.google.com/style/inclusive-documentation
 
 * Use gender-neutral language wherever possible (firefighter vs fireman)
 * Use gender-neutral pronouns when referring to a hypothetical person ("they" instead of "he or she"), even if that requires changing a verb conjugation ("they **adjust** their settings" vs "he or she **adjusts** his or her settings")
-* Avoid terms like master/slave or blacklist/whitelist - use parent/child or denylist/allowlist
-	* blacklist/whitelist can be used as verbs or nouns, while denylist/allowlist tend to only be used as nouns; consider "add to the allowlist" as a replacement for the verb form of "whitelist"
+* Avoid unnecessarily using socially-charged terms for technical concepts
+	* For example, avoid terms such as blacklist, whitelist, sanity check, and first-class citizen. Instead, consider denylist, allowlist, overall check, first-class object, etc
 * Avoid calling tasks "simple" or "easy" as it may frustrate users who are finding it to not be all that easy
 	* It is acceptable to use comparisons, e.g. to say that something is easier than something else
 
@@ -107,5 +107,4 @@ Adapted from: https://developers.google.com/style/tone
 * Never include any humor at the expense of a person, organization, or group of people
 * You can make the case for a feature's existence, but avoid sounding too much like a salesperson
 * When telling someone to preform a task in a tutorial, use second-person implicit whenever it makes sense to do so -- e.g., write "Click this button to delete System32" instead of "You can click this button to delete System32"
-* In general, try to avoid passive voice -- e.g., write "Click this button to delete System32" instead of "This button can be clicked to delete System32"
- 
+* In general, try to avoid passive voice -- e.g., write "Click this button to delete System32" instead of "This button can be clicked to delete System32" 

--- a/style-guide.md
+++ b/style-guide.md
@@ -24,7 +24,7 @@ See also: [Google's guidelines for accessibility](https://developers.google.com/
 * If talking about a program that does not support certain operating systems, make it clear which systems are supported relatively early in documentation introducing that program
 	* If possible, give an alternative for unsupported OSs
 	* "The Dockstore CLI is only supported on Unix-like operating systems, including Linux and Mac. Windows users may wish to..."
-* Keep in mind users might be using an HPC
+* Keep in mind users might be working in a high performance computing (HPC) environment
 	* Assume that if they are using an HPC, they know how to use their HPC's job submission system (SLURM, etc)
 	* If working with/installing something requiring root permissions such as Docker, mention that root permission is needed once, then assume from that point forward that your HPC users have root privileges
 	* If a program you introduce runs differently on an HPC, beyond needing root privileges, make note of those differences

--- a/style-guide.md
+++ b/style-guide.md
@@ -93,8 +93,12 @@ See also: [Google's guidelines for inclusive documentation](https://developers.g
 ## Technical detail
 * Generally speaking, assume that your audience is computer literate but may not know their way around the command line, git, Docker, or workflow languages
 	* This will vary - a user seeking out best practices for a specific workflow language will know what a workflow language is
-* Keep track of technical phrases and add them to the glossary if they are not already defined in the glossary
+* Keep track of technical phrases and acronyms, and add them to the glossary if they are not already defined in the glossary
 	* What is considered a "technical phrase" can be nebulous; use your best judgment
+	* Define language-specific acronyms (CWL, WDL, etc) the first time they are rendered on an HTML page
+	* Define CLI when introducing the concept to new users, but you do not need to define it in all docs about the Dockstore CLI
+* Glossary terms should define the functional meaning of acronyms for your audience, not just what they stand for
+	* Example: If your audiance are pet owners, "Light Amplification by the Stimulated Emission of Radiation" is much less helpful than "a device that emits light based on stimulation of electromagnetic radiation, which can be used to create a small red dot that cats find fascinating"
 * Focus more on the how-to-do-things than what's happening under the hood
 
 ## Timeliness

--- a/style-guide.md
+++ b/style-guide.md
@@ -43,7 +43,8 @@ See also: https://developers.google.com/style/accessibility
 * Write in RST, not markdown
 * Use `.. comment` to write comments
 * Use consistent indentation spacing within a single RST file
-* Do not break up body text with a newline every x characters
+* Keep all sentences in a given paragraph that renders as body text on one line, i.e. do not break up body text every x characters
+* Make RST tables human-readible instead of compact -- consider using [this table generator](https://tableconvert.com/restructuredtext-generator)
 * Use \`this style \<https://example.com\>_` of formatting external hyperlinks, as it is less error prone than the method involving setting the target in another paragraph
 * Use headings in this way throughout the entire repository to avoid issues with embedding RST files into other RST files:
 

--- a/style-guide.md
+++ b/style-guide.md
@@ -1,0 +1,112 @@
+# Dockstore Docs Style Guide
+
+This style guide is based upon [Google's style guide](https://developers.google.com/style/) but contains several sections specific to Dockstore itself. It is not exhaustive nor authoritative; this document is designed as a quick reference guide.
+
+## Accessibility
+See also: https://developers.google.com/style/accessibility
+
+* Always set descriptive alt text for images, except for decorative images
+ 	* If the image contains important text, repeat that text in the alt text
+	 	* Although it is tricky due to how documentation websites tend to use images to clarify written text,  try to avoid having alt text repeat what is in the body text
+	 	* Do not start with "image of" or "picture of" but do describe the type of image, like:
+	 		* "Headshot of David Haussler smiling"
+		 	* "Screenshot of the UI of dockstore.org/my-tools with the Refresh Organization button circled"
+		 	* "Animation of a tabby cat jumping three feet into the air upon noticing a cucumber"
+* Keep in mind ~5% of the population is red-green colorblind
+	* 	When color schemes convey non-essential meaning, avoid using color schemes that would be inaccessible to red-green colorblind users
+	* 	When color schemes convey essential meaning (vital UI elements, etc) they should be functional in grayscale
+* Do not use things that would be a nightmare for screen readers
+ 	* Avoid using non-ASCII symbols 𝙨𝙪𝙘𝙝 𝙖𝙨 𝙩𝙝𝙞𝙨, 𝙬𝙝𝙞𝙘𝙝 𝙪𝙨𝙚𝙨 𝙘𝙤𝙙𝙚𝙥𝙤𝙞𝙣𝙩𝙨 𝙙𝙚𝙨𝙞𝙜𝙣𝙚𝙙 𝙛𝙤𝙧 𝙢𝙖𝙩𝙝𝙚𝙢𝙖𝙩𝙞𝙘𝙨, 𝙣𝙤𝙩 𝙩𝙚𝙭𝙩
+		* Exception: Examples showing non-English text such as 山田太郎
+		* Using actual bold and italics formatting is acceptable, but bear in mind screen readers may not declare something as being bold or italic
+
+## Assumptions about a user's system
+* If talking about a program that does not support certain operating systems, make it clear which systems are supported relatively early in documentation introducing that program
+	* If possible, give an alternative for unsupported OSs
+	* "The Dockstore CLI is only supported on Unix-like operating systems, including Linux and Mac. Windows users may wish to..."
+* Do not assume users are or are not using an HPC
+	* Assume that if they are using an HPC, they at least know how to use their HPC's job submission system (SLURM, etc)
+	* If working with/installing something requiring root permissions such as Docker, mention that root permission is needed once, then assume from that point forward that your HPC users have root privileges
+	* However, do not assume that HPC users know how programs you introduce may work differently on an HPC
+		* Example: Running a WDL on an HPC via Cromwell (ie via the Dockstore CLI) requires additional runtime arguments that a local user does not need to include in their WDL program, so make sure to either include those runtime arguments in your examples or tell HPC users what additional things they need
+* Assume Linux users are using Ubuntu or know how to translate into their own distro
+	* Exception: If directing very new users to install software via apt-get, consider mentioning that the instructions are specific to Ubuntu -- UCSC's linux lab for students runs on CentOS (which uses yum instead) so this is not a rare occurrence
+* Keep in mind that some of our users are using Macs, so make a note about these situations in the text if they occur:
+	* If there is an important functional difference between the Linux and the Mac version, such as xargs
+	* If there is an important installation difference between the Linux and the Mac version, such as the installation of the Dockstore CLI
+	* If something does not work/works differently on Apple Silicon Macs
+	* If there is an important difference between the bash and zsh version of something
+		* Do not assume that a Mac user is aware of whether they are using bash or zsh (the default changed in Catalina) or knows how to change between the two
+		* Do not worry about other shells
+
+## Coding in RST
+* Write in RST, not markdown
+* Use `.. comment` to write comments
+* Use consistent indentation spacing within a single RST file
+* Do not break up body text with a newline every x characters
+* Use use \`this style <https://example.com>\`_ of formatting external hyperlinks, as it is less error prone than the method involving setting the target in another paragraph
+* Use headings in this way throughout the entire repository to avoid issues with embedding RST files into other RST files:
+
+> `page title`
+> `==========`
+> 
+> `heading level 1`
+> `---------------`
+>
+> `heading level 2`
+> `~~~~~~~~~~~~~~~`
+>
+> `heading level 3`
+> `***************`
+>
+> `heading level 4`
+> `+++++++++++++++`
+>
+> `heading level 5`
+> `\``````````````
+>
+ 
+## International
+See also: https://developers.google.com/style/translation 
+
+* Avoid using idioms ("it's raining cats and dogs in Santa Cruz")
+* Avoid using culturally-specific comparisons ("the button is green like a dollar bill")
+* Try to use relatively simple English whenever possible
+* Make sure programs/templates you are providing to the user have a way to handle non-ASCII names, family-name-first ordering, and names with apostrophes and hyphens
+
+## Inclusion
+See also: https://developers.google.com/style/inclusive-documentation
+
+* Use gender-neutral language wherever possible (firefighter vs fireman)
+* Use gender-neutral pronouns when referring to a hypothetical person ("they" instead of "he or she"), even if that requires changing a verb conjugation ("they **adjust** their settings" vs "he or she **adjusts** his or her settings")
+* Avoid terms like master/slave or blacklist/whitelist - use parent/child or denylist/allowlist
+	* blacklist/whitelist can be used as verbs or nouns, while denylist/allowlist tend to only be used as nouns; consider "add to the allowlist" as a replacement for the verb form of "whitelist"
+* Avoid calling tasks "simple" or "easy" as it may frustrate users who are finding it to not be all that easy
+	* It is acceptable to use comparisons, ie to say that something is easier than something else
+
+## Logos
+* Before using a new logo for an external organization or moving an existing logo to a place where it has a next context, make a good-faith effort to reach out to the organization for approval if usage of that logo is not clear from their policy
+* Do not use NHLBI logos, including the BioData Catalyst logo, except where it has been explicitly approved
+* Review the logo policy for specific organizations on the Social Media and Outreach Policy document (ask for Google Drive access if necessary)
+
+## Technical detail
+* Generally speaking, assume that your audience is computer literate but may not know their way around the command line, git, Docker, or workflow languages
+	* This will vary - a user seeking out best practices for a specific workflow language will know what a workflow language is
+* Keep track of technical phrases and add them to the glossary if they are not already defined in the glossary
+	* What is considered a "technical phrase" can be nebulous; use your best judgment
+* Focus more on the how-to-do-things than what's happening under the hood
+
+## Timeliness
+* Follow these guidelines: https://developers.google.com/style/timeless-documentation
+* In places where it is truly necessary to anchor something to a point in time, consider adding an RST comment reading `.. !time` nearby so that later maintainers of the documentation will be able to search all such instances and update them as necessary.
+
+## Tone
+Adapted from: https://developers.google.com/style/tone
+* Humor in the form of slightly silly examples is okay, but generally keep things formal
+	* "My Cool Workflow", etc is okay
+* Never include any humor at the expense of a person, organization, or group of people
+* You can make the case for a feature's existence, but avoid sounding too much like a salesperson
+* When describing someone doing a task, use second-person implicit whenever it makes sense to do so, but try to stick to active voice
+	* Active voice: "Click Refresh Organization to delete System 32."
+	* Passive voice: "Refresh Organization can be clicked to delete System 32."
+ 

--- a/style-guide.md
+++ b/style-guide.md
@@ -44,7 +44,7 @@ See also: [Google's guidelines for accessibility](https://developers.google.com/
 * Use `.. comment` to write comments
 * Use consistent indentation spacing within a single RST file
 * Keep all sentences in a given paragraph that renders as body text on one line, i.e. do not break up body text every x characters
-* Make RST tables human-readible instead of compact -- consider using [this table generator](https://tableconvert.com/restructuredtext-generator)
+* Make RST tables human-readable instead of compact -- consider using [this table generator](https://tableconvert.com/restructuredtext-generator)
 * Use \`this style \<https://example.com\>_` of formatting external hyperlinks, as it is less error prone than the method involving setting the target in another paragraph
 * Use headings in this way throughout the entire repository to avoid issues with embedding RST files into other RST files:
 
@@ -98,7 +98,7 @@ See also: [Google's guidelines for inclusive documentation](https://developers.g
 	* Define language-specific acronyms (CWL, WDL, etc) the first time they are rendered on an HTML page
 	* Define CLI when introducing the concept to new users, but you do not need to define it in all docs about the Dockstore CLI
 * Glossary terms should define the functional meaning of acronyms for your audience, not just what they stand for
-	* Example: If your audiance are pet owners, "Light Amplification by the Stimulated Emission of Radiation" is much less helpful than "a device that emits light based on stimulation of electromagnetic radiation, which can be used to create a small red dot that cats find fascinating"
+	* Example: If your audience are pet owners, "Light Amplification by the Stimulated Emission of Radiation" is much less helpful than "a device that emits light based on stimulation of electromagnetic radiation, which can be used to create a small red dot that cats find fascinating"
 * Focus more on the how-to-do-things than what's happening under the hood
 
 ## Timeliness

--- a/style-guide.md
+++ b/style-guide.md
@@ -24,20 +24,20 @@ See also: https://developers.google.com/style/accessibility
 * If talking about a program that does not support certain operating systems, make it clear which systems are supported relatively early in documentation introducing that program
 	* If possible, give an alternative for unsupported OSs
 	* "The Dockstore CLI is only supported on Unix-like operating systems, including Linux and Mac. Windows users may wish to..."
-* Do not assume users are or are not using an HPC
-	* Assume that if they are using an HPC, they at least know how to use their HPC's job submission system (SLURM, etc)
+* Keep in mind users might be using an HPC
+	* Assume that if they are using an HPC, they know how to use their HPC's job submission system (SLURM, etc)
 	* If working with/installing something requiring root permissions such as Docker, mention that root permission is needed once, then assume from that point forward that your HPC users have root privileges
-	* However, do not assume that HPC users know how programs you introduce may work differently on an HPC
-		* Example: Running a WDL on an HPC via Cromwell (e.g. via the Dockstore CLI) requires additional runtime arguments that a local user does not need to include in their WDL program, so make sure to either include those runtime arguments in your examples or tell HPC users what additional things they need
-* Assume Linux users are using Ubuntu or know how to translate into their own distro
-	* Exception: If directing very new users to install software via apt-get, consider mentioning that the instructions are specific to Ubuntu -- UCSC's linux lab for students runs on CentOS (which uses yum instead) so this is not a rare occurrence
-* Keep in mind that some of our users are using Macs, so make a note about these situations in the text if they occur:
+	* If a program you introduce runs differently on an HPC, beyond needing root privileges, make note of those differences
+		* Example: Running a WDL on an HPC via Cromwell (e.g. via the Dockstore CLI) requires additional runtime arguments that a local user does not need to include in their WDL program, tell HPC users what additional things they need
+* When talking about Linux, mention that your instructions are specific to Ubuntu, and from that point on in the document assume users are either using Ubuntu or know how to translate into their own distribution
+	* Exception: If directing users to install software via apt-get, provide alternatives for Red Hat (yum), Arch (pacman), and Gentoo (emerge) if those alternatives are available
+* Make a note about these Mac-specific situations in the text if they occur:
 	* If there is an important functional difference between the Linux and the Mac version, such as xargs
 	* If there is an important installation difference between the Linux and the Mac version, such as the installation of the Dockstore CLI
 	* If something does not work/works differently on Apple Silicon Macs
-	* If there is an important difference between the bash and zsh version of something
-		* Do not assume that a Mac user is aware of whether they are using bash or zsh (the default changed in Catalina) or knows how to change between the two
-		* Do not worry about other shells
+* If the bash and zsh version of something would be different, provided both versions
+	* Unless this bash/zsh difference only applies to Linux, make note of the fact that zsh is the default shell in Mac OS as of Catalina (10.15)
+	* Do not worry about other shells besides bash and zsh
 
 ## Coding in RST
 * Write in RST, not markdown

--- a/style-guide.md
+++ b/style-guide.md
@@ -112,5 +112,7 @@ Adapted from [Google's style guide r/e tone](https://developers.google.com/style
 	* "My Cool Workflow", etc is okay
 * Never include any humor at the expense of a person, organization, or group of people
 * You can make the case for a feature's existence, but avoid sounding too much like a salesperson
-* When telling someone to preform a task in a tutorial, use second-person implicit whenever it makes sense to do so -- e.g., write "Click this button to delete System32" instead of "You can click this button to delete System32"
-* In general, try to avoid passive voice -- e.g., write "Click this button to delete System32" instead of "This button can be clicked to delete System32" 
+* Use [second-person](https://developers.google.com/style/person) whenever it makes sense to do so
+* When telling someone to preform a task in a tutorial or otherwise using imperatives, make the second-person subject [implicit](https://editorsmanual.com/articles/sentence-implied-subject-grammar/)
+	* Example: "Click this button to delete System32" instead of "You can click this button to delete System32"
+* Use [active voice](https://developers.google.com/style/voice)

--- a/style-guide.md
+++ b/style-guide.md
@@ -28,7 +28,7 @@ See also: https://developers.google.com/style/accessibility
 	* Assume that if they are using an HPC, they at least know how to use their HPC's job submission system (SLURM, etc)
 	* If working with/installing something requiring root permissions such as Docker, mention that root permission is needed once, then assume from that point forward that your HPC users have root privileges
 	* However, do not assume that HPC users know how programs you introduce may work differently on an HPC
-		* Example: Running a WDL on an HPC via Cromwell (ie via the Dockstore CLI) requires additional runtime arguments that a local user does not need to include in their WDL program, so make sure to either include those runtime arguments in your examples or tell HPC users what additional things they need
+		* Example: Running a WDL on an HPC via Cromwell (e.g. via the Dockstore CLI) requires additional runtime arguments that a local user does not need to include in their WDL program, so make sure to either include those runtime arguments in your examples or tell HPC users what additional things they need
 * Assume Linux users are using Ubuntu or know how to translate into their own distro
 	* Exception: If directing very new users to install software via apt-get, consider mentioning that the instructions are specific to Ubuntu -- UCSC's linux lab for students runs on CentOS (which uses yum instead) so this is not a rare occurrence
 * Keep in mind that some of our users are using Macs, so make a note about these situations in the text if they occur:
@@ -44,7 +44,7 @@ See also: https://developers.google.com/style/accessibility
 * Use `.. comment` to write comments
 * Use consistent indentation spacing within a single RST file
 * Do not break up body text with a newline every x characters
-* Use use \`this style \<https://example.com\>_` of formatting external hyperlinks, as it is less error prone than the method involving setting the target in another paragraph
+* Use \`this style \<https://example.com\>_` of formatting external hyperlinks, as it is less error prone than the method involving setting the target in another paragraph
 * Use headings in this way throughout the entire repository to avoid issues with embedding RST files into other RST files:
 
 > `page title`  
@@ -72,7 +72,7 @@ See also: https://developers.google.com/style/translation
 * Avoid using idioms ("it's raining cats and dogs in Santa Cruz")
 * Avoid using culturally-specific comparisons ("the button is green like a dollar bill")
 * Try to use relatively simple English whenever possible
-* Make sure programs/templates you are providing to the user have a way to handle non-ASCII names, family-name-first ordering, and names with apostrophes and hyphens
+* Make sure programs/templates you are providing to the user have a way to handle non-ASCII names and names with apostrophes and hyphens
 
 ## Inclusion
 See also: https://developers.google.com/style/inclusive-documentation
@@ -82,7 +82,7 @@ See also: https://developers.google.com/style/inclusive-documentation
 * Avoid terms like master/slave or blacklist/whitelist - use parent/child or denylist/allowlist
 	* blacklist/whitelist can be used as verbs or nouns, while denylist/allowlist tend to only be used as nouns; consider "add to the allowlist" as a replacement for the verb form of "whitelist"
 * Avoid calling tasks "simple" or "easy" as it may frustrate users who are finding it to not be all that easy
-	* It is acceptable to use comparisons, ie to say that something is easier than something else
+	* It is acceptable to use comparisons, e.g. to say that something is easier than something else
 
 ## Logos
 * Before using a new logo for an external organization or moving an existing logo to a place where it has a next context, make a good-faith effort to reach out to the organization for approval if usage of that logo is not clear from their policy

--- a/style-guide.md
+++ b/style-guide.md
@@ -3,7 +3,7 @@
 This style guide is based upon [Google's style guide](https://developers.google.com/style/) but contains several sections specific to Dockstore itself. It is not exhaustive nor authoritative; this document is designed as a quick reference guide.
 
 ## Accessibility
-See also: https://developers.google.com/style/accessibility
+See also: [Google's guidelines for accessibility](https://developers.google.com/style/accessibility)
 
 * Always set descriptive alt text for images, except for decorative images
  	* If the image contains important text, repeat that text in the alt text
@@ -67,8 +67,8 @@ See also: https://developers.google.com/style/accessibility
 > `\``````````````
 >
  
-## International
-See also: https://developers.google.com/style/translation 
+## International/Translation
+See also: [Google's guidelines r/e translation](https://developers.google.com/style/translation) 
 
 * Avoid using idioms ("it's raining cats and dogs in Santa Cruz")
 * Avoid using culturally-specific comparisons ("the button is green like a dollar bill")
@@ -76,7 +76,7 @@ See also: https://developers.google.com/style/translation
 * Make sure programs/templates you are providing to the user have a way to handle non-ASCII names and names with apostrophes and hyphens
 
 ## Inclusion
-See also: https://developers.google.com/style/inclusive-documentation
+See also: [Google's guidelines for inclusive documentation](https://developers.google.com/style/inclusive-documentation).
 
 * Use gender-neutral language wherever possible (firefighter vs fireman)
 * Use gender-neutral pronouns when referring to a hypothetical person ("they" instead of "he or she"), even if that requires changing a verb conjugation ("they **adjust** their settings" vs "he or she **adjusts** his or her settings")
@@ -98,11 +98,12 @@ See also: https://developers.google.com/style/inclusive-documentation
 * Focus more on the how-to-do-things than what's happening under the hood
 
 ## Timeliness
-* Follow these guidelines: https://developers.google.com/style/timeless-documentation
+* Follow [Google's timeless documentation guidelines](https://developers.google.com/style/timeless-documentation)
 * In places where it is truly necessary to anchor something to a point in time, consider adding an RST comment reading `.. !time` nearby so that later maintainers of the documentation will be able to search all such instances and update them as necessary.
 
 ## Tone
-Adapted from: https://developers.google.com/style/tone
+Adapted from [Google's style guide r/e tone](https://developers.google.com/style/tone)
+
 * Humor in the form of slightly silly examples is okay, but generally keep things formal
 	* "My Cool Workflow", etc is okay
 * Never include any humor at the expense of a person, organization, or group of people

--- a/style-guide.md
+++ b/style-guide.md
@@ -16,8 +16,8 @@ See also: https://developers.google.com/style/accessibility
 	* 	When color schemes convey non-essential meaning, avoid using color schemes that would be inaccessible to red-green colorblind users
 	* 	When color schemes convey essential meaning (vital UI elements, etc) they should be functional in grayscale
 * Do not use things that would be a nightmare for screen readers
- 	* Avoid using non-ASCII symbols 𝙨𝙪𝙘𝙝 𝙖𝙨 𝙩𝙝𝙞𝙨, 𝙬𝙝𝙞𝙘𝙝 𝙪𝙨𝙚𝙨 𝙘𝙤𝙙𝙚𝙥𝙤𝙞𝙣𝙩𝙨 𝙙𝙚𝙨𝙞𝙜𝙣𝙚𝙙 𝙛𝙤𝙧 𝙢𝙖𝙩𝙝𝙚𝙢𝙖𝙩𝙞𝙘𝙨, 𝙣𝙤𝙩 𝙩𝙚𝙭𝙩
-		* Exception: Examples showing non-English text such as 山田太郎
+ 	* Avoid using non-ASCII symbols unless you are writing something meaningful in another language
+ 		* For example, do not use symbols from U+1D400 𝒔𝒖𝒄𝒉 𝒂𝒔 𝒕𝒉𝒆𝒔𝒆 as a replacement for ***actual bold and italic formatting***
 		* Using actual bold and italics formatting is acceptable, but bear in mind screen readers may not declare something as being bold or italic
 
 ## Assumptions about a user's system

--- a/style-guide.md
+++ b/style-guide.md
@@ -95,7 +95,7 @@ See also: [Google's guidelines for inclusive documentation](https://developers.g
 	* This will vary - a user seeking out best practices for a specific workflow language will know what a workflow language is
 * Keep track of technical phrases and acronyms, and add them to the glossary if they are not already defined in the glossary
 	* What is considered a "technical phrase" can be nebulous; use your best judgment
-	* Define language-specific acronyms (CWL, WDL, etc) the first time they are rendered on an HTML page
+	* Define language-specific acronyms (CWL, WDL, etc) the first time they are used in a document
 	* Define CLI when introducing the concept to new users, but you do not need to define it in all docs about the Dockstore CLI
 * Glossary terms should define the functional meaning of acronyms for your audience, not just what they stand for
 	* Example: If your audience are pet owners, "Light Amplification by the Stimulated Emission of Radiation" is much less helpful than "a device that emits light based on stimulation of electromagnetic radiation, which can be used to create a small red dot that cats find fascinating"


### PR DESCRIPTION
This PR adds a style guide for our documentation. It loosely based on Google's style guide and repeats a few important points from it, but the emphasis is on parts specific to our users. It is written in markdown with the RST portions escaped as necessary to make it render as expected.

This PR does not attempt to change existing documentation to align with the guide, but once this is approved, I intend on making some changes to that end.