### PR TITLE
Replace wonky link in docker-alternatives.rst

### DIFF
--- a/docs/advanced-topics/docker-alternatives.rst
+++ b/docs/advanced-topics/docker-alternatives.rst
@@ -7,7 +7,7 @@ Docker Alternatives
 In some situations using Docker may be impractical because it requires all users to have root access.
 Several alternatives have been developed to make it possible to run rootless containers, including
 `Singularity <https://sylabs.io/docs/>`_ and 
-`rootless Docker <https://engineering.docker.com/2019/02/experimenting-with-rootless-docker/>`_.
+`rootless Docker <https://medium.com/@tonistiigi/experimenting-with-rootless-docker-416c9ad8c0d6>`_.
 While Dockstore uses Docker by default, if necessary it may be possible to run your workflows with one
 of these alternatives. Because the call to Docker or an alternative is made by the workflow runner, usually cwltool
 or Cromwell, and not Dockstore directly, the difficulty of configuring a Docker alternative depends on the workflow

--- a/docs/advanced-topics/docker-alternatives.rst
+++ b/docs/advanced-topics/docker-alternatives.rst
@@ -7,7 +7,7 @@ Docker Alternatives
 In some situations using Docker may be impractical because it requires all users to have root access.
 Several alternatives have been developed to make it possible to run rootless containers, including
 `Singularity <https://sylabs.io/docs/>`_ and 
-`rootless Docker <https://medium.com/@tonistiigi/experimenting-with-rootless-docker-416c9ad8c0d6>`_.
+`rootless Docker <https://www.docker.com/blog/experimenting-with-rootless-docker/>`_.
 While Dockstore uses Docker by default, if necessary it may be possible to run your workflows with one
 of these alternatives. Because the call to Docker or an alternative is made by the workflow runner, usually cwltool
 or Cromwell, and not Dockstore directly, the difficulty of configuring a Docker alternative depends on the workflow


### PR DESCRIPTION
We have a link to Docker's blog r/e rootless Docker. Recently, it has begun occasionally but not always failing during `make linkcheck`. As of my making this PR, builds are passing on CircleCI but my browser is still throwing gateway errors on that URL.

It just so happens the author of the blog mirrored it on Medium, so this is an easy fix. Will add reviewers + look to merge this if CI begins failing again. Might just be a temporary hiccup.