### PR TITLE
Remove extra newlines in a handful of docs pages

### DIFF
--- a/docs/dockstore-introduction.rst
+++ b/docs/dockstore-introduction.rst
@@ -11,6 +11,7 @@ Built with Docker and Git
 .. note:: See `Docker Overview <https://docs.docker.com/get-started/overview/>`__ for an excellent overview about Docker.
 
 Docker repositories, like `Docker Hub <https://hub.docker.com/>`__, `Quay.io <https://quay.io/>`__ and `GitLab <https://about.gitlab.com>`__, and source control repositories like `GitHub <https://github.com>`__, `Bitbucket <https://bitbucket.org/>`__, and `GitLab <https://about.gitlab.com>`__, provide much of the infrastructure we need. Docker repositories allow users to build, publish, and share both public and private Docker images. However, the services lack standardized ways of describing how to invoke tools contained within Docker containers. Workflow descriptor languages provide standardised ways to define the inputs, parameterizations, and outputs of tools in a controlled way. Together, these resources provide the necessary tools to share analytical tools in a highly portable way, a key concern for the scientific community. 
+
 .. figure:: /assets/images/docs/Ways_to_get_into_Dockstore.png
    :alt: Overview
 

--- a/docs/dockstore-introduction.rst
+++ b/docs/dockstore-introduction.rst
@@ -1,46 +1,16 @@
 About Dockstore
 ===============
 
-The Dockstore concept is simple; provide a place where users can share
-tools encapsulated in Docker and described with the `Common Workflow
-Language <https://www.commonwl.org/>`__ (CWL) or
-`Workflow Description Language <https://openwdl.org/>`__ (WDL),
-workflow languages used by members of and APIs created by the
-`GA4GH <https://www.ga4gh.org>`__ `Cloud Work
-Stream <http://ga4gh.cloud/>`__. This enables scientists, for example,
-to share analytical tools in a way that makes them machine readable and
-runnable in a variety of environments. While the Dockstore is focused on
-serving researchers in the biosciences, the combination of Docker +
-CWL/WDL can be used by anyone to describe the tools and services in
-their `Docker images <https://docs.docker.com/get-started/overview/#docker-objects>`__ in a standardized, machine-readable way.
+The Dockstore concept is simple; provide a place where users can share tools encapsulated in Docker and described with the `Common Workflow Language <https://www.commonwl.org/>`__ (CWL) or `Workflow Description Language <https://openwdl.org/>`__ (WDL), workflow languages used by members of and APIs created by the `GA4GH <https://www.ga4gh.org>`__ `Cloud Work Stream <http://ga4gh.cloud/>`__. This enables scientists, for example, to share analytical tools in a way that makes them machine readable and runnable in a variety of environments. While the Dockstore is focused on serving researchers in the biosciences, the combination of Docker + CWL/WDL can be used by anyone to describe the tools and services in their `Docker images <https://docs.docker.com/get-started/overview/#docker-objects>`__ in a standardized, machine-readable way. 
 
-Dockstore also attempts to work with new and alternative
-languages/standards such as `Nextflow <https://www.nextflow.io/>`__ as
-popular challengers to CWL and WDL. We also work on the `GA4GH Tool
-Registry <https://github.com/ga4gh/tool-registry-service-schemas>`__ standard as
-a way of sharing data with workflow platforms and partners. We are also
-working with the task execution, workflow execution, and data transfer
-standards developing at the GA4GH.
+Dockstore also attempts to work with new and alternative languages/standards such as `Nextflow <https://www.nextflow.io/>`__ as popular challengers to CWL and WDL. We also work on the `GA4GH Tool Registry <https://github.com/ga4gh/tool-registry-service-schemas>`__ standard as a way of sharing data with workflow platforms and partners. We are also working with the task execution, workflow execution, and data transfer standards developing at the GA4GH. 
 
 Built with Docker and Git
 -------------------------
 
 .. note:: See `Docker Overview <https://docs.docker.com/get-started/overview/>`__ for an excellent overview about Docker.
 
-Docker repositories, like `Docker Hub <https://hub.docker.com/>`__,
-`Quay.io <https://quay.io/>`__ and `GitLab <https://about.gitlab.com>`__, and
-source control repositories like `GitHub <https://github.com>`__,
-`Bitbucket <https://bitbucket.org/>`__, and
-`GitLab <https://about.gitlab.com>`__, provide much of the infrastructure we
-need. Docker repositories allow users to build, publish, and share both
-public and private Docker images. However, the services lack
-standardized ways of describing how to invoke tools contained within
-Docker containers. Workflow descriptor languages provide standardised
-ways to define the inputs, parameterizations, and outputs of tools in a
-controlled way. Together, these resources provide the necessary tools to
-share analytical tools in a highly portable way, a key concern for the
-scientific community.
-
+Docker repositories, like `Docker Hub <https://hub.docker.com/>`__, `Quay.io <https://quay.io/>`__ and `GitLab <https://about.gitlab.com>`__, and source control repositories like `GitHub <https://github.com>`__, `Bitbucket <https://bitbucket.org/>`__, and `GitLab <https://about.gitlab.com>`__, provide much of the infrastructure we need. Docker repositories allow users to build, publish, and share both public and private Docker images. However, the services lack standardized ways of describing how to invoke tools contained within Docker containers. Workflow descriptor languages provide standardised ways to define the inputs, parameterizations, and outputs of tools in a controlled way. Together, these resources provide the necessary tools to share analytical tools in a highly portable way, a key concern for the scientific community. 
 .. figure:: /assets/images/docs/Ways_to_get_into_Dockstore.png
    :alt: Overview
 
@@ -66,40 +36,16 @@ C) You will be able to use our new hosted workflows service to store
    tools and workflows directly on dockstore.org to quickly get started,
    prototype your ideas, and share workflows with a limited audience.
 
-In all three cases, you will have an opportunity to clean-up and
-configure your work before publishing to the rest of the world to see.
+In all three cases, you will have an opportunity to clean-up and configure your work before publishing to the rest of the world to see.
 
-You can mix and match in a number of these approaches. For example, you
-can go beyond our simple tutorials and automated approach to manually
-register tools that point at locations like Docker Hub, Seven Bridges,
-and Amazon ECR. You can substitute WDL and Nextflow for the descriptor
-language for workflows. You might even be able to mix and match
-descriptor languages eventually!
+You can mix and match in a number of these approaches. For example, you can go beyond our simple tutorials and automated approach to manually register tools that point at locations like Docker Hub, Seven Bridges, and Amazon ECR. You can substitute WDL and Nextflow for the descriptor language for workflows. You might even be able to mix and match descriptor languages eventually! 
 
-Over time, we find "skinny" Docker images, those with single tools
-installed in them, are more helpful for extending and building new
-workflows with. That being said, "fat" Docker containers, which include
-multiple tools and even full workflows with frameworks like
-`SeqWare <https://seqware.github.io/>`__ or
-`Galaxy <https://galaxyproject.org/>`__, can have their place as well.
-Projects like the ICGC `PanCancer Analysis of Whole
-Genomes <https://dcc.icgc.org/pcawg>`__ (PCAWG) made use of "fat" Docker
-containers that had complex workflows that fully encapsulated alignment
-and variant calling. The self-contained nature of these Docker
-containers allowed for mobility between a wide variety of environments
-and greatly simplified the setup of these pipelines across a wide
-variety of HPC and cloud environments. Either approach works for the
-Dockstore so long as you can describe the tool or workflow inside the
-Docker container as a CWL/WDL-defined tool (which you can for most
-things).
+Over time, we find "skinny" Docker images, those with single tools installed in them, are more helpful for extending and building new workflows with. That being said, "fat" Docker containers, which include multiple tools and even full workflows with frameworks like `SeqWare <https://seqware.github.io/>`__ or `Galaxy <https://galaxyproject.org/>`__, can have their place as well. Projects like the ICGC `PanCancer Analysis of Whole Genomes <https://dcc.icgc.org/pcawg>`__ (PCAWG) made use of "fat" Docker containers that had complex workflows that fully encapsulated alignment and variant calling. The self-contained nature of these Docker containers allowed for mobility between a wide variety of environments and greatly simplified the setup of these pipelines across a wide variety of HPC and cloud environments. Either approach works for the Dockstore so long as you can describe the tool or workflow inside the Docker container as a CWL/WDL-defined tool (which you can for most things). 
 
 Promoting Standards
 -------------------
 
-We hope Dockstore provides a reference implementation for tool sharing
-in the sciences. The Dockstore is essentially a living and evolving
-proof of concept designed as a starting point for two activities that we
-hope will result in community standards within the GA4GH:
+We hope Dockstore provides a reference implementation for tool sharing in the sciences. The Dockstore is essentially a living and evolving proof of concept designed as a starting point for two activities that we hope will result in community standards within the GA4GH: 
 
 -  a best practices guide for describing tools in Docker containers with
    CWL/WDL/Nextflow
@@ -108,29 +54,17 @@ hope will result in community standards within the GA4GH:
    indexed by multiple websites similar to `Maven
    Central <https://search.maven.org/>`__
 
-We also implement certain utilities such as file provisioning plugins
-that support the GA4GH DOS (Data Object Service) standard or
-command-line launchers that present a common interface across CWL and
-WDL as almost a polyfill to demonstrate what we wish to use over time
-natively.
+We also implement certain utilities such as file provisioning plugins that support the GA4GH DOS (Data Object Service) standard or command-line launchers that present a common interface across CWL and WDL as almost a polyfill to demonstrate what we wish to use over time natively. 
 
 Building a Community
 --------------------
 
-Several large projects in the Biosciences, specifically cancer
-sequencing projects such as PCAWG, PrecisionFDA, the Broad Institute,
-the University of California Santa Cruz, and Cancer IT at Sanger have
-registered between 10 and 60 workflows each in Dockstore as of August
-2018. We hope this work will aid the community and promote the
-registration of a large number of high-quality workflows in the system.
+Several large projects in the Biosciences, specifically cancer sequencing projects such as PCAWG, PrecisionFDA, the Broad Institute, the University of California Santa Cruz, and Cancer IT at Sanger have registered between 10 and 60 workflows each in Dockstore as of August 2018. We hope this work will aid the community and promote the registration of a large number of high-quality workflows in the system. 
 
 Future Plans
 ------------
 
-We plan on expanding the Dockstore in several ways over the coming
-months. Please see our `issues
-page <https://github.com/dockstore/dockstore/issues>`__ for details and
-discussions.
+We plan on expanding the Dockstore in several ways over the coming months. Please see our `issues page <https://github.com/dockstore/dockstore/issues>`__ for details and discussions.
 
 For longer term plans, please see our `roadmap page <https://github.com/dockstore/dockstore/wiki/Dockstore-Roadmap>`__.
 

--- a/docs/getting-started/getting-started.rst
+++ b/docs/getting-started/getting-started.rst
@@ -11,10 +11,7 @@ This series is an introduction to everything required to properly use Dockstore 
 - :doc:`Creating a Dockstore account </getting-started/register-on-dockstore>`
 - Registering :doc:`a tool </getting-started/dockstore-tools>` or :doc:`a workflow </getting-started/dockstore-workflows>` on Dockstore
 
-The tool we will be using throughout this tutorial is
-`BAMStats <http://bamstats.sourceforge.net/>`__. It is a tool for
-summarising Next Generation Sequencing alignments. It accepts a BAM file
-as input and produces a ZIP file containing an HTML report on the alignment.
+The tool we will be using throughout this tutorial is `BAMStats <http://bamstats.sourceforge.net/>`__. It is a tool for summarising Next Generation Sequencing alignments. It accepts a BAM file as input and produces a ZIP file containing an HTML report on the alignment.
 
 Note that this tutorial series assumes you are running on a system that can run Docker. This isn't the case for all users, especially HPC users. Read :doc:`our notes on Docker alternatives </advanced-topics/docker-alternatives>` for more details.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,12 +3,9 @@ Welcome to Dockstore Documentation!
 
 .. note:: Our code lives on GitHub at `dockstore/dockstore <https://github.com/dockstore/dockstore>`_ and `dockstore/dockstore-ui2 <https://github.com/dockstore/dockstore-ui2>`_.
 
-Dockstore is an open platform used by the `GA4GH <https://www.ga4gh.org/>`__ for sharing Docker-based tools, workflows, and services.
-For tools and workflows, we support Common Workflow Language (CWL), Workflow Description Language (WDL), Nextflow (NFL), and Galaxy.
+Dockstore is an open platform used by the `GA4GH <https://www.ga4gh.org/>`__ for sharing Docker-based tools, workflows, and services. For tools and workflows, we support Common Workflow Language (CWL), Workflow Description Language (WDL), Nextflow (NFL), and Galaxy.
 
-If this is your first time learning about Dockstore, we recommend starting with the :doc:`Getting Started Guide <getting-started/getting-started>`. This will introduce
-you to the core concepts of Dockstore, leaving you with a good understanding of the platform. However, if you are simply looking to launch tools and workflows, we recommend
-going straight to the :doc:`End User Topics <end-user-topics/end-user-topics>` or our `quickstart guide <https://dockstore.org/quick-start>`_.
+If this is your first time learning about Dockstore, we recommend starting with the :doc:`Getting Started Guide <getting-started/getting-started>`. This will introduce you to the core concepts of Dockstore, leaving you with a good understanding of the platform. However, if you are simply looking to launch tools and workflows, we recommend going straight to the :doc:`End User Topics <end-user-topics/end-user-topics>` or our `quickstart guide <https://dockstore.org/quick-start>`_.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Previously we (somewhat inconsistently) used a "newline every x characters" style. Since most content in this repo is text rendered to the user, and in attempt to make changes easier to see, I went against this in the style guide. I haven't changed all documents to conform to that though, as that'd be a very large PR, nor is it high priority.

I'm thinking it's best to do it in stages, only as doc pages are ready to be changed for another issue anyway. This not only makes the changes to paragraphs to conform to the style guide, but it can also serve as a base branch to make necessary changes easier to see.

To that end -- in order to make changes between 1.12.1 and upcoming changes for https://github.com/dockstore/dockstore/issues/4785 easy to compare, I am going to use this as the base branch for the eventual pull request for feature/4785.