### PR TITLE
Remove 1.13 references

### DIFF
--- a/docs/advanced-topics/dockstore-cli/advanced-features.rst
+++ b/docs/advanced-topics/dockstore-cli/advanced-features.rst
@@ -332,8 +332,6 @@ with the `Cromwell <https://github.com/broadinstitute/cromwell>`__ version liste
 +-------------+-----------------------+
 |     1.12    |          57           |
 +-------------+-----------------------+
-|     1.13    |          77           |
-+-------------+-----------------------+
 
 Additionally, you can override the Cromwell version in your
 ``~/.dockstore/config`` using for example:


### PR DESCRIPTION
Closes https://github.com/dockstore/dockstore/issues/5026

This appears to be the only thing referencing 1.13.

I decided not to remove everything else that the rebase picked up, because everything else is valid for 1.12 and honestly belongs on master anyway, since it includes important updates and removes some outdated content. If it wasn't for the rebase, I was going to propose merging develop into master after merging the latest hotfix branch.

If hubflow considers this a hotfix branch, it will merge to develop and main, so after merging this I will need to open a feature branch to revert these changes on develop. 