### PR TITLE
Add a FAQ entry for duplicate ORCID accounts

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,9 @@ linkcheck_ignore = [
     'https://doi.org/10.7490/f1000research.1118300.1',
     'launch-with/anvil-launch-with.html', 'launch-with/cavatica-launch-with.html', 'launch-with/dnanexus-launch-with.html', 'launch-with/cgc-launch-with.html',
     'launch-with/galaxy-launch-with.html', 'launch-with/nextflow-tower-launch-with.html', 'launch-with/terra-launch-with.html',
-    'https://doi.org/*'
+    'https://doi.org/*',
+    # Confusing, linkcheck and curl report expired cert, but cert date is correct in browser
+    'https://support.orcid.org/hc/en-us/articles/360006971593-Do-you-have-more-than-one-account'
     ]
 
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -347,6 +347,13 @@ Any last tips on using Dockstore?
 -  related to the two above, you can use non-standard file paths if you
    customize your registrations in the Version tab of Dockstore
 
+What happens if I link to a different ORCID account?
+----------------------------------------------------
+
+`ORCID <https://orcid.org>`__ is designed to `discourage more than one account for an individual <https://support.orcid.org/hc/en-us/articles/360006971593-Do-you-have-more-than-one-account->`__. However, if you somehow end up with two ORCID accounts, publish a record from Dockstore using the first ORCID account, then relink Dockstore to the second ORCID account, you will not be able to update the original ORCID record from within Dockstore.
+
+If you run into this situation, please use the `Help Desk` link in the https://dockstore.org footer to contact the Dockstore team.
+
 .. |DOI| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.321679.svg
    :target: https://zenodo.org/record/321679
 


### PR DESCRIPTION
dockstore/dockstore#4243

This is such an out-there edge case, I'm not convinced we should have it, but I suppose it doesn't hurt. Screenshot from local build:

![Screen Shot 2022-09-09 at 5 16 42 PM](https://user-images.githubusercontent.com/1049340/189460997-2fc7229a-c6ed-49ae-828e-ba07133bb9a2.png)

I went "use the Help Desk link" instead of an actual link in case we ever want to change the Help Desk url.