### PR TITLE
Add cromwell version 84 to table for 1.14

### DIFF
--- a/docs/advanced-topics/dockstore-cli/advanced-features.rst
+++ b/docs/advanced-topics/dockstore-cli/advanced-features.rst
@@ -331,6 +331,8 @@ with the `Cromwell <https://github.com/broadinstitute/cromwell>`__ version liste
 +-------------+-----------------------+
 |     1.13    |          77           |
 +-------------+-----------------------+
+|     1.14    |          84           |
++-------------+-----------------------+
 
 Additionally, you can override the Cromwell version in your
 ``~/.dockstore/config`` using for example:


### PR DESCRIPTION
https://ucsc-cgl.atlassian.net/browse/SEAB-4980

Adds a new row indicating that 1.14 uses cromwell version 84