### PR TITLE
Add information on readMePath

### DIFF
--- a/docs/assets/templates/template.rst
+++ b/docs/assets/templates/template.rst
@@ -12,6 +12,7 @@ Tips and tricks
 * This form of registration is only available to workflows, tools, and services that are hosted on GitHub
 * Make sure your file is saved as ``.dockstore.yml``, not ``dockstore.yml`` or ``.dockstore.yaml``
 * Put the .dockstore.yml file in the top of your repo or inside ``.github/``
+* If you have multiple workflows/tools/services in a single GitHub repository, each one needs a unique ``name``, and it's a good idea (but not strictly required) to give each one a unique ``readMePath`` too. 
 * The first line of a .dockstore.yml file references the version of .dockstore.yml syntax being used, not the version/tag of the workflow/tool/service it describes
 * You can use a single .dockstore.yml file to register multiple tools and workflows, provided they are all in the same repo as the .dockstore.yml file
 * A **workflow** registered with via a .dockstore.yml file is not fundamentally different than a workflow registered in another method, other than the fact that the .dockstore.yml version will be kept up-to-date automatically -- but a .dockstore.yml registered **tool** is different from tools registered in other methods (:ref:`see this table for more information <dockstore yml tools vs old school tools>`)

--- a/docs/assets/templates/workflows/example-3-multiworkflow-multiauthor.dockstore.yml
+++ b/docs/assets/templates/workflows/example-3-multiworkflow-multiauthor.dockstore.yml
@@ -2,6 +2,7 @@ version: 1.2
 workflows:
   - subclass: WDL
     primaryDescriptorPath: /assoc-aggregate/assoc-aggregate.wdl
+    readMePath: /assoc-aggregate/readme.md
     testParameterFiles:
       - /assoc-aggregate/assoc-aggregate-terra-allele.json
       - /assoc-aggregate/assoc-aggregate-terra-position.json
@@ -11,6 +12,7 @@ workflows:
       - orcid: 0000-0003-4896-1858
   - subclass: WDL
     primaryDescriptorPath: /pc-air/pc-air.wdl
+    readMePath: /pc-air/README.md
     testParameterFiles:
       - /pc-air/pc-air-local.json
       - /pc-air/pc-air-terra.json

--- a/docs/assets/templates/workflows/template-big.dockstore.yml
+++ b/docs/assets/templates/workflows/template-big.dockstore.yml
@@ -37,6 +37,11 @@ workflows:
     #   - /null-model/null-model-binary.json
     testParameterFiles: <String Array>
 
+    # An optional path to a workflow-specific readme in the Git repository. If not provided, Dockstore will show
+    # the readme.md present at the root of the Git repository if it is present.
+    # If you have multiple workflows in a single Git repository, it is recommend to give each one a readme.
+    readMePath: <String>
+
     # An optional array of authorship information.
     # Note that if orcid is present, then all other fields will be ignored, as information will be taken from orcid.
     # If orcid is not present, make sure to at a minimum include the name field for each author.

--- a/docs/assets/templates/workflows/template-small.dockstore.yml
+++ b/docs/assets/templates/workflows/template-small.dockstore.yml
@@ -3,6 +3,7 @@ workflows:
   - subclass: <CWL | WDL | NFL | GALAXY>
     primaryDescriptorPath: <String>
     testParameterFiles: <String Array>
+    readMePath: <String>
     authors:
       - name: <String>
         email: <String>

--- a/docs/assets/templates/workflows/workflows.rst
+++ b/docs/assets/templates/workflows/workflows.rst
@@ -14,7 +14,7 @@ Always use :ref:`absolute paths <dict absolute path>` to specify the :ref:`prima
 
 Filled-out example of a single workflow without a name
 ------------------------------------------------------
-In this example, the workflow author is identified with an orcid. When an orcid is specified, there is no need to specify an author's name and email as that information will be pulled from the orcid. There are also three test parameter files given for the workflow. Since no readMePath is specified, Dockstore will show the top-level readme (if one is present), eg, ``./readme.md``
+In this example, the workflow author is identified with an ORCID iD. When an ORCID iD is specified, there is no need to specify an author's name and email as that information will be pulled from the ORCID API. There are also three test parameter files given for the workflow. Since no readMePath is specified, Dockstore will show the top-level readme (if one is present), eg, ``/readme.md``
 
 .. include:: /assets/templates/workflows/example-1-noname.yml
   :code:

--- a/docs/assets/templates/workflows/workflows.rst
+++ b/docs/assets/templates/workflows/workflows.rst
@@ -10,11 +10,11 @@ Simple generic template for a workflow
 .. include:: /assets/templates/workflows/template-small.dockstore.yml
   :code:
 
-Always use :ref:`absolute paths <dict absolute path>` to specify the :ref:`primary descriptor <dict primary descriptor file>` and :ref:`test parameter <dict parameter file>` files.
+Always use :ref:`absolute paths <dict absolute path>` to specify the :ref:`primary descriptor <dict primary descriptor file>`, :ref:`test parameter <dict parameter file>`, and readMePath files.
 
 Filled-out example of a single workflow without a name
 ------------------------------------------------------
-In this example, the workflow author is identified with an orcid. When an orcid is specified, there is no need to specify an author's name and email as that information will be pulled from the orcid. There are also three test parameter files given for the workflow.
+In this example, the workflow author is identified with an orcid. When an orcid is specified, there is no need to specify an author's name and email as that information will be pulled from the orcid. There are also three test parameter files given for the workflow. Since no readMePath is specified, Dockstore will show the top-level readme (if one is present), eg, ``./readme.md``
 
 .. include:: /assets/templates/workflows/example-1-noname.yml
   :code:
@@ -28,9 +28,9 @@ This example is identical to the one above, but the workflow in question now is 
 
 Filled-out example of multiple workflows in the same repository
 ---------------------------------------------------------------
-First, you will notice that we swapped the order of the ``name`` and ``author`` fields for association-aggregate-wdl compared to the examples above, to demonstrate that the order is arbitrary. Next, we added a new section for pc-air-wdl, which has a different author and its own test parameter files and descriptor file. 
+First, you will notice that we swapped the order of the ``name`` and ``author`` fields for assoc-aggregate-wdl compared to the examples above, to demonstrate that the order is arbitrary. Next, we added a new section for pc-air-wdl, which has a different author and its own test parameter files and descriptor file. We have also added the optional ``readMePath`` value to these workflows so that each entry gets its own workflow-specific readme.
 
-This .dockstore.yml will result in the creation of two entries on Dockstore -- one for association-aggregate-wdl, and one for pc-air-wdl.
+This .dockstore.yml will result in the creation of two entries on Dockstore -- one for assoc-aggregate-wdl, and one for pc-air-wdl. assoc-aggregate-wdl's entry will show the readme located at ``/assoc-aggreate/readme.md``, while pc-air-wdl's entry will show the readme located at ``/pc-air/README.md``. Although ``readMePath`` is optional, if we did not add it to these entries, both entries would instead show the same top-level readme.md (or README.md) of the git repo.
 
 .. include:: /assets/templates/workflows/example-3-multiworkflow-multiauthor.dockstore.yml
   :code:

--- a/docs/dictionary.rst
+++ b/docs/dictionary.rst
@@ -198,7 +198,7 @@ BioData Catalyst
 ----------------
     A cloud-based platform funded by :ref:`dict NHLBI` to provide tools, applications, and workflows in secure workspaces to expand research in heart, lung, blood, and sleep health.  
 
-Further reading: `<https://www.nhlbi.nih.gov/science/biodata-catalyst>`_
+Further reading: `<https://dockstore.org/organizations/bdcatalyst>`_  
 
 
 
@@ -493,7 +493,7 @@ entry
 
 environment variable
 --------------------
-    A variable that affects how processes run on a computer. For example, :ref:`dict cwltool` references the environment variable $TMPDIR when deciding where to place files. You can set environment variables in Bash using the `export` command. Environment variables are sometimes called env var or env for short.  
+    A variable that affects how processes run on a computer. For example, :ref:`dict cwltool` references the environment variable $TMPDIR when deciding where to place files.  
 
 Further reading: `<https://en.wikipedia.org/wiki/Environment_variable>`_  
 

--- a/docs/getting-started/github-apps/github-apps.rst
+++ b/docs/getting-started/github-apps/github-apps.rst
@@ -41,7 +41,7 @@ the Refresh button or making an API call to the Dockstore API.
 Due to the manual nature of this process, it is easy for Dockstore to get out of
 sync with the linked GitHub repository if the Dockstore GitHub App is not being used.
 
-The Dockstore GitHub App also makes it easy to register multiple workflows in the same repository quickly, as well as set up their metadata (test parameter files, authors, readmes, etc).
+The Dockstore GitHub App also makes it easy to register multiple workflows in the same repository quickly, as well as set up their metadata (test parameter files, authors, readmes, etc). You can even publish a workflow or set a default branch from the .dockstore.yml which can be useful for both automated systems and users registering workflows in bulk. 
 
 How the Dockstore GitHub App works
 ----------------------------------

--- a/docs/getting-started/github-apps/github-apps.rst
+++ b/docs/getting-started/github-apps/github-apps.rst
@@ -41,6 +41,8 @@ the Refresh button or making an API call to the Dockstore API.
 Due to the manual nature of this process, it is easy for Dockstore to get out of
 sync with the linked GitHub repository if the Dockstore GitHub App is not being used.
 
+The Dockstore GitHub App also makes it easy to register multiple workflows in the same repository quickly, as well as set up their metadata (test parameter files, authors, readmes, etc).
+
 How the Dockstore GitHub App works
 ----------------------------------
 


### PR DESCRIPTION
* Adds readMePath to the big and small blank templates
* Adds readMePath to the multi-workflow template
* Add a tip that if you are making many entries from a single GitHub repo, each one needs a unique name* and should have a unique readme
* Add a selling point to the "Why use the GHA?" docs

_*iirc you can technically leave one workflow nameless provided n-1 have a name but that's not a good idea so I'm not going to remind users of that_