### PR TITLE
Describe Open Data

### DIFF
--- a/discourse-topic-check.sh
+++ b/discourse-topic-check.sh
@@ -31,10 +31,14 @@ fi
 
 for file in $(git diff --name-only "$baseBranch".. | grep "\.rst$" | grep -Fvxf $DOES_NOT_REQUIRE_DISCOURSE_TOPIC)
 do
-  if ! containsDiscourseTopic "$file"
+  # The file may be in the base branch but not the current branch. Skip in that case.
+  if [[ -f "$file" ]]
   then
-    echo "${file} does not have a discourse topic"
-    RETURN_VALUE=1
+    if ! containsDiscourseTopic "$file"
+    then
+      echo "${file} does not have a discourse topic"
+      RETURN_VALUE=1
+    fi
   fi
 done
 

--- a/docs/_static/language-support.html
+++ b/docs/_static/language-support.html
@@ -105,8 +105,8 @@
         </tr>
         <tr style="border-top: 1px solid #ddd; ">
             <td style="padding: 5px;"><a href="../faq.html#what-is-an-open-tool-or-workflow">Open Data</a></td>
-            <td style="background-color:#dff0d8; padding: 5px;">Yes <sup>11</sup></td>
-            <td style="background-color:#dff0d8; padding: 5px;">Yes<sup>12</sup></td>
+            <td style="background-color:#dff0d8; padding: 5px;">Yes <sup>[11]</sup></td>
+            <td style="background-color:#dff0d8; padding: 5px;">Yes<sup>[12]</sup></td>
             <td style="background-color:lightgray; padding: 5px;">No</td>
             <td style="background-color:lightgray; padding: 5px;">No</td>
         </tr>

--- a/docs/_static/language-support.html
+++ b/docs/_static/language-support.html
@@ -104,6 +104,13 @@
             <td style="background-color:#dff0d8; padding: 5px;">Yes</td>
         </tr>
         <tr style="border-top: 1px solid #ddd; ">
+            <td style="padding: 5px;"><a href="../faq.html#what-is-an-open-tool-or-workflow">Open Data</a></td>
+            <td style="background-color:#dff0d8; padding: 5px;">Yes <sup>11</sup></td>
+            <td style="background-color:#dff0d8; padding: 5px;">Yes<sup>12</sup></td>
+            <td style="background-color:lightgray; padding: 5px;">No</td>
+            <td style="background-color:lightgray; padding: 5px;">No</td>
+        </tr>
+        <tr style="border-top: 1px solid #ddd; ">
             <th style="padding: 5px;">Dockstore CLI</th>
             <th style="padding: 5px;"></th>
             <th style="padding: 5px;"></th>
@@ -192,7 +199,7 @@
             <td style="background-color:lightgray; padding: 5px;">No</td>
         </tr>
         <tr style="border-top: 1px solid #ddd; ">
-            <td style="padding: 5px;"><a href="../advanced-topics/advanced-features.html#notifications">Notifications</a></td>
+            <td style="padding: 5px;"><a href="../advanced-topics/dockstore-cli/advanced-features.html#notifications">Notifications</a></td>
             <td style="background-color:#dff0d8; padding: 5px;">Yes</td>
             <td style="background-color:#dff0d8; padding: 5px;">Yes</td>
             <td style="background-color:lightgray; padding: 5px;">No</td>

--- a/docs/advanced-topics/dockstore-tools-overhaul.rst
+++ b/docs/advanced-topics/dockstore-tools-overhaul.rst
@@ -13,6 +13,8 @@ At a Glance
 .. include:: /advanced-topics/legacy/table--legtool-vs-ghatool.rst
 
 
+.. _legacy_tools:
+
 Dockstore Tools Prior to 1.12 (Legacy Tools)
 --------------------------------------------
 

--- a/docs/end-user-topics/language-support.rst
+++ b/docs/end-user-topics/language-support.rst
@@ -39,6 +39,10 @@ Limitations <terra-limitations>` for limitations.
 
 [10] Use the Dockstore CLI optional parameter --wdl-output-target which allows you to specify a remote path to provision output files to ex: s3://oicr.temp/testing-launcher/
 
+[11] For workflows and :ref:`GitHub App Tools <what-is-an-open-tool-or-workflow>`, not for :ref:`Legacy Tools <legacy_tools>`.
+
+[12] For workflows only, not tools.
+
 
 .. _converting-file-path-based-imports-to-public-http-s-based-imports-for-wdl:
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -66,6 +66,19 @@ not limited to):
     ``$ dockstore tool launch --entry quay.io/cancercollaboratory/dockstore-tool-bedgraph-bigwig --json Dockstore.json``
 4. The docker pull command in the tools search reflects the defaultversion
 
+.. _what-is-an-open-tool-or-workflow:
+
+What is an Open Data tool or workflow version?
+----------------------------------------------
+
+On Dockstore, an Open Data tool or workflow version includes everything needed to run the version, without any
+additional data access. This usually means there is a test parameter file whose file input parameter values
+only refer to open data -- data that is not restricted access nor costs any money to download.
+
+Note that tool and workflow versions that do not require any file input parameters are also considered Open Data.
+
+You can find Open Data workflows and tools by selecting the Open Data facet on the `search <https://dockstore.org/search>`_ page.
+When viewing an individual tool or workflow, you can tell which versions are Open Data on the Versions tab via the Open column.
 
 How should I register my work in Dockstore?
 -------------------------------------------


### PR DESCRIPTION
dockstore/dockstore#5402

While writing it, noticed that the notifications link in the language support table did not work; fixed that as well.

Build is [here](https://docs.dockstore.org/en/feature-5402-opendata/) if you wish to view the built form.

Discourse topic check was failing because a file existed on develop that didn't exist on the release1.14 branch. Updated to handle that case after discussion with Steve.