### PR TITLE
DOCK-2347: Mention AGC wdl input S3 URL requirement

### DIFF
--- a/docs/advanced-topics/docker-alternatives.rst
+++ b/docs/advanced-topics/docker-alternatives.rst
@@ -122,7 +122,7 @@ Podman
 Podman is a daemon-less alternative of Docker that allows end users to run Docker/Open Container Initiative (OCI) containers without root privileges.
 
 Podman can be installed following the instructions
-`here <https://podman.io/docs/tutorials/installation>`__.
+`here <https://podman.io/docs/installation>`__.
 
 cwltool
 ~~~~~~~

--- a/docs/advanced-topics/docker-alternatives.rst
+++ b/docs/advanced-topics/docker-alternatives.rst
@@ -122,7 +122,7 @@ Podman
 Podman is a daemon-less alternative of Docker that allows end users to run Docker/Open Container Initiative (OCI) containers without root privileges.
 
 Podman can be installed following the instructions
-`here <https://podman.io/getting-started/installation>`__.
+`here <https://podman.io/docs/tutorials/installation>`__.
 
 cwltool
 ~~~~~~~

--- a/docs/advanced-topics/wes/wes-wdl-agc-tutorial.rst
+++ b/docs/advanced-topics/wes/wes-wdl-agc-tutorial.rst
@@ -38,8 +38,9 @@ The following WDL workflow tutorials will cover:
                 "workflowInputs": <pathToInputJSON>
             }
 
-    2. AWS AGC references descriptor files by URLs. The Dockstore CLI references the primary descriptor in an execution request as a GA4GH Tool Registry Service (`TRS <https://github.com/ga4gh/tool-registry-service-schemas>`_) URL.
-    The AGC infrastructure will only be able to access the file referenced by the TRS URL if the workflow is published (i.e. public) on Dockstore.
+    2. AWS AGC references descriptor files by URLs. The Dockstore CLI references the primary descriptor in an execution request as a GA4GH Tool Registry Service (`TRS <https://github.com/ga4gh/tool-registry-service-schemas>`_) URL.  The AGC infrastructure will only be able to access the file referenced by the TRS URL if the workflow is published (i.e. public) on Dockstore.
+
+    3. On AWS AGC, the test parameter file for a WDL workflow must reference other files using S3 URLs.  Other types of URLs, such as `https:`, are not supported.
 
 Configuring AGC and the Dockstore CLI
 ----------------------------------------

--- a/docs/advanced-topics/wes/wes-wdl-agc-tutorial.rst
+++ b/docs/advanced-topics/wes/wes-wdl-agc-tutorial.rst
@@ -40,7 +40,7 @@ The following WDL workflow tutorials will cover:
 
     2. AWS AGC references descriptor files by URLs. The Dockstore CLI references the primary descriptor in an execution request as a GA4GH Tool Registry Service (`TRS <https://github.com/ga4gh/tool-registry-service-schemas>`_) URL.  The AGC infrastructure will only be able to access the file referenced by the TRS URL if the workflow is published (i.e. public) on Dockstore.
 
-    3. On AWS AGC, the test parameter file for a WDL workflow must reference other files using S3 URLs.  Other types of URLs, including `https:`, are not supported.
+    3. On AWS AGC, the test parameter file for a WDL workflow running in Cromwell must reference other files using S3 URLs.  Other types of URLs, including `https:`, are not supported.
 
 Configuring AGC and the Dockstore CLI
 ----------------------------------------

--- a/docs/advanced-topics/wes/wes-wdl-agc-tutorial.rst
+++ b/docs/advanced-topics/wes/wes-wdl-agc-tutorial.rst
@@ -40,7 +40,7 @@ The following WDL workflow tutorials will cover:
 
     2. AWS AGC references descriptor files by URLs. The Dockstore CLI references the primary descriptor in an execution request as a GA4GH Tool Registry Service (`TRS <https://github.com/ga4gh/tool-registry-service-schemas>`_) URL.  The AGC infrastructure will only be able to access the file referenced by the TRS URL if the workflow is published (i.e. public) on Dockstore.
 
-    3. On AWS AGC, the test parameter file for a WDL workflow must reference other files using S3 URLs.  Other types of URLs, such as `https:`, are not supported.
+    3. On AWS AGC, the test parameter file for a WDL workflow must reference other files using S3 URLs.  Other types of URLs, including `https:`, are not supported.
 
 Configuring AGC and the Dockstore CLI
 ----------------------------------------


### PR DESCRIPTION
Adds a note about how S3 urls are required to reference files from a WDL test parameter file on AWS AGC. 

Also, a podman page moved, this PR updates the link.

**Issue**
https://ucsc-cgl.atlassian.net/browse/DOCK-2347
[#5416](https://github.com/dockstore/dockstore/issues/5416)