### PR TITLE
Feature/minor faq improvements

### DIFF
--- a/docs/_attic/glossary_entries.py
+++ b/docs/_attic/glossary_entries.py
@@ -506,6 +506,10 @@ ParameterFile = GlossEntry("parameter file",
 	institute="", 
 	pronunciation='')
 
+ParentImage = GlossEntry("parent image", 
+	definition="A [Docker image] which acts as the base upon which another Docker image is built. For example, including FROM ubuntu:18.04 in a [Dockerfile] means that the resulting image will include everything inside ubuntu:18.04, plus any changes made by other commands in the Dockerfile. Parent images are sometimes called base images, but strictly speaking a base image is different (see further reading).", 
+	furtherreading="https://docs.docker.com/glossary/#parent-image")
+
 Preemptible = GlossEntry("preemptible", 
 	acronym_full="", 
 	definition="A type of [GCP] [VM] which may have its running jobs interrupted at any given time, and will be shut down if running for more than 24 hours. A preemptible machine is significantly cheaper than a standard VM, at the cost of possibly stopping before your computational work is finished. You can use preemptible machines when running workflows on GCP backends to save on compute costs.", 

--- a/docs/_attic/glossary_entries.py
+++ b/docs/_attic/glossary_entries.py
@@ -507,7 +507,7 @@ ParameterFile = GlossEntry("parameter file",
 	pronunciation='')
 
 ParentImage = GlossEntry("parent image", 
-	definition="A [Docker image] which acts as the base upon which another Docker image is built. For example, including FROM ubuntu:18.04 in a [Dockerfile] means that the resulting image will include everything inside ubuntu:18.04, plus any changes made by other commands in the Dockerfile. Parent images are sometimes called base images, but strictly speaking a base image is different (see further reading).", 
+	definition="A [Docker image] which acts as the base upon which another Docker image is built. For example, including FROM ubuntu:22.04 in a [Dockerfile] means that the resulting image will include everything inside ubuntu:22.04, plus any changes made by other commands in the Dockerfile. Parent images are sometimes called base images, but strictly speaking a base image is different (see further reading).", 
 	furtherreading="https://docs.docker.com/glossary/#parent-image")
 
 Preemptible = GlossEntry("preemptible", 

--- a/docs/_attic/glossary_entries_list_dynamic.txt
+++ b/docs/_attic/glossary_entries_list_dynamic.txt
@@ -70,6 +70,7 @@ OICR
 ORCID
 organization
 parameter file
+parent image
 preemptible
 primary descriptor file
 secondary descriptor file

--- a/docs/advanced-topics/dockstore-cli/dockstore-cli-faq.rst
+++ b/docs/advanced-topics/dockstore-cli/dockstore-cli-faq.rst
@@ -1,3 +1,5 @@
+.. _topCLIFAQ:
+
 Dockstore CLI FAQ
 =================
 
@@ -17,6 +19,8 @@ FTP, S3, and GCS. As of Release 1.12, the Dockstore CLI has support for running 
 client <https://docs.icgc.org/download/guide/#score-client-usage>`__. Please see `file provisioning plugins <https://github.com/dockstore/dockstore-cli/tree/master/dockstore-file-plugin-parent>`__
 for more information on these two file transfer sources.
 
+:ref:`(back to top) <topCLIFAQ>`
+
 .. _how-do-i-use-the-dockstore-cli-on-a-mac:
 
 How do I use the Dockstore CLI on a Mac?
@@ -33,6 +37,8 @@ can change what it allocates using the Docker for Mac GUI under
 `here <https://docs.docker.com/docker-for-mac/#advanced>`__.
 
 The default allocation can cause workflows or tools to fail without informing the user with a memory or resource related error message. If you find that your workflow or tool is behaving differently on a Mac compared to a similarly resourced Ubuntu environment, you can try increasing the resources allocated to Docker on the Mac to resolve the discrepancy. If you are using WDL, see also our notes on :doc:`local Cromwell configuration files`</advanced-topics/dockstore-cli/local-cromwell-config>`.
+
+:ref:`(back to top) <topCLIFAQ>`
 
 Why am I getting "Mount denied" errors when launching workflows on Mac?
 -----------------------------------------------------------------------
@@ -66,6 +72,7 @@ Depending on the permissions available to your machine, you may be able to give 
 
 $TMPDIR might be set to a subfolder of /private/var/folders. If you are still having issues, try adding /var/folders to Docker's list of accessible directories instead.
 
+:ref:`(back to top) <topCLIFAQ>`
 
 How do I launch tools/workflows without internet access on compute nodes?
 -------------------------------------------------------------------------
@@ -82,6 +89,8 @@ follow these steps:
 The Dockstore CLI will automatically load all Docker images in the
 directory specified prior to a ``launch --local-entry`` command.
 
+:ref:`(back to top) <topCLIFAQ>`
+
 .. _return-code-wdl:
 
 How do I find the return code for a WDL task?
@@ -89,8 +98,9 @@ How do I find the return code for a WDL task?
 
 The numeric return code for a WDL task will be in that task's execution folder. It is a single file named `rc` with no extension. Generally speaking, a 0 is a success, and anything else is a failure.
 
-Let's say you are running [this vcf-to-gds file conversion workflow](https://dockstore.org/workflows/github.com/DataBiosphere/analysis_pipeline_WDL/vcf-to-gds-wdl:v7.1.1), which runs the check-gds task as a scattered task on an array of three files. Cromwell will refer to each instance of that scattered task as a "shard" and will name them starting with 0. If you notice that shard 0 seems to have failed, look for `/cromwell-executions/[workflow ID]/call-check_gds/shard-0/execution/rc` keeping in mind that the workflow ID will usually be a long mix of numbers, letters, and dashes such as 18a85cc0-aa59-4749-b1b9-e2580ed5e557.
+Let's say you are running [this vcf-to-gds file conversion workflow](https://dockstore.org/workflows/github.com/DataBiosphere/analysis_pipeline_WDL/vcf-to-gds-wdl:v7.1.1), which runs the check-gds task as a scattered task on an array of three files. Cromwell will refer to each instance of that scattered task as a "shard" and will name them starting with 0. If you notice that shard 0 seems to have failed, look for `/cromwell-executions/[workflow ID]/call-check_gds/shard-0/execution/rc` keeping in mind that the workflow ID will usually be a long mix of numbers, letters, and dashes such as 18a85cc0-aa59-4749-b1b9-e2580ed5e557  
 
+:ref:`(back to top) <topCLIFAQ>`
 
 .. _cromwell-docker-lockup:
 
@@ -103,7 +113,9 @@ If a Docker lockup happens, you will notice in-progress WDL tasks do not progres
 
 The other issue we often see is some instances of scattered tasks getting `sigkilled <https://www.gnu.org/software/libc/manual/html_node/Termination-Signals.html>`__ by the operating system. You will know when this happens because the `rc` (return code) file will read 137. If it reads anything except 137, then you can assume that it wasn't actually a resource management error and look in stderr or stdout for the true culprit. For more on return codes, see :ref:`this FAQ <return-code-wdl>` entry.
 
-To prevent these issues from happening, we recommend setting up your Cromwell configuration file to limit how many scattered tasks run at once, and then setting up the Dockstore CLI to make use of that Cromwell configuration file. :doc:`A step-by-step tutorial is available here. </advanced-topics/dockstore-cli/local-cromwell-config>`
+To prevent these issues from happening, we recommend setting up your Cromwell configuration file to limit how many scattered tasks run at once, and then setting up the Dockstore CLI to make use of that Cromwell configuration file. :doc:`A step-by-step tutorial is available here. </advanced-topics/dockstore-cli/local-cromwell-config>` 
+
+:ref:`(back to top) <topCLIFAQ>`
 
 The CLI is failing with Java 8 or 11
 ------------------------------------
@@ -121,7 +133,9 @@ The Dockstore CLI as of 1.7.0 is compiled and tested using Java 11 due
 to the Java 8 EOL. You will need to upgrade from Java 8 to use CLI versions betweenn 1.7 and 1.13.
 
 The Dockstore CLI as of 1.14.0 is compiled and tested using Java 17 due
-to the approaching Java 11 EOL. You will need to update to Java 17 to use the CLI version 1.14.0+.
+to the approaching Java 11 EOL. You will need to update to Java 17 to use the CLI version 1.14.0+. 
+
+:ref:`(back to top) <topCLIFAQ>`
 
 .. discourse::
     :topic_identifier: 6481

--- a/docs/advanced-topics/dockstore-cli/dockstore-cli-faq.rst
+++ b/docs/advanced-topics/dockstore-cli/dockstore-cli-faq.rst
@@ -117,6 +117,20 @@ To prevent these issues from happening, we recommend setting up your Cromwell co
 
 :ref:`(back to top) <topCLIFAQ>`
 
+What environment do you test tools in?
+--------------------------------------
+
+Typically, we test running tools in Ubuntu Linux 16.04 LTS on VMs in
+`OpenStack <https://www.openstack.org/>`__ with 8 vCPUs and 96 GB of RAM
+and above. We've also begun testing on Ubuntu 18.04 LTS and so far it's
+been successful. If you are only listing and editing tools, we have
+achieved success with much lower system requirements. However, launching
+tools will have higher system requirements dependent on the specific
+tool. Consult a tool's README or CWL/WDL/Nextflow description when in doubt.
+
+:ref:`(back to top) <topCLIFAQ>`
+
+
 The CLI is failing with Java 8 or 11
 ------------------------------------
 

--- a/docs/advanced-topics/dockstore-cli/dockstore-cli-faq.rst
+++ b/docs/advanced-topics/dockstore-cli/dockstore-cli-faq.rst
@@ -98,7 +98,7 @@ How do I find the return code for a WDL task?
 
 The numeric return code for a WDL task will be in that task's execution folder. It is a single file named `rc` with no extension. Generally speaking, a 0 is a success, and anything else is a failure.
 
-Let's say you are running [this vcf-to-gds file conversion workflow](https://dockstore.org/workflows/github.com/DataBiosphere/analysis_pipeline_WDL/vcf-to-gds-wdl:v7.1.1), which runs the check-gds task as a scattered task on an array of three files. Cromwell will refer to each instance of that scattered task as a "shard" and will name them starting with 0. If you notice that shard 0 seems to have failed, look for `/cromwell-executions/[workflow ID]/call-check_gds/shard-0/execution/rc` keeping in mind that the workflow ID will usually be a long mix of numbers, letters, and dashes such as 18a85cc0-aa59-4749-b1b9-e2580ed5e557  
+Let's say you are running [this vcf-to-gds file conversion workflow](https://dockstore.org/workflows/github.com/DataBiosphere/analysis_pipeline_WDL/vcf-to-gds-wdl:v7.1.1), which runs the check-gds task as a scattered task on an array of three files. Cromwell will refer to each instance of that scattered task as a "shard" and will name them starting with 0. If you notice that shard 0 seems to have failed, look for `/cromwell-executions/[workflow ID]/call-check_gds/shard-0/execution/rc` keeping in mind that the workflow ID will usually be a long mix of numbers, letters, and dashes such as 18a85cc0-aa59-4749-b1b9-e2580ed5e557.  
 
 :ref:`(back to top) <topCLIFAQ>`
 

--- a/docs/dictionary.rst
+++ b/docs/dictionary.rst
@@ -76,6 +76,7 @@ Dockstore Dictionary
 	* :ref:`dict ORCID`
 	* :ref:`dict organization`
 	* :ref:`dict parameter file`
+	* :ref:`dict parent image`
 	* :ref:`dict preemptible`
 	* :ref:`dict primary descriptor file`
 	* :ref:`dict secondary descriptor file`
@@ -887,6 +888,16 @@ parameter file
 --------------
     A :ref:`dict JSON` or :ref:`dict YAML` file that describes the inputs to a workflow, such as runtime parameters or links to cloud data.  
 
+
+
+
+.. _dict parent image:
+
+parent image
+------------
+    A :ref:`dict Docker image` which acts as the base upon which another Docker image is built. For example, including FROM ubuntu:18.04 in a :ref:`dict Dockerfile` means that the resulting image will include everything inside ubuntu:18.04, plus any changes made by other commands in the Dockerfile. Parent images are sometimes called base images, but strictly speaking a base image is different (see further reading).  
+
+Further reading: `<https://docs.docker.com/glossary/#parent-image>`_  
 
 
 

--- a/docs/dictionary.rst
+++ b/docs/dictionary.rst
@@ -895,7 +895,7 @@ parameter file
 
 parent image
 ------------
-    A :ref:`dict Docker image` which acts as the base upon which another Docker image is built. For example, including FROM ubuntu:18.04 in a :ref:`dict Dockerfile` means that the resulting image will include everything inside ubuntu:18.04, plus any changes made by other commands in the Dockerfile. Parent images are sometimes called base images, but strictly speaking a base image is different (see further reading).  
+    A :ref:`dict Docker image` which acts as the base upon which another Docker image is built. For example, including FROM ubuntu:22.04 in a :ref:`dict Dockerfile` means that the resulting image will include everything inside ubuntu:22.04, plus any changes made by other commands in the Dockerfile. Parent images are sometimes called base images, but strictly speaking a base image is different (see further reading).  
 
 Further reading: `<https://docs.docker.com/glossary/#parent-image>`_  
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1,3 +1,5 @@
+.. _topFAQ:
+
 FAQ
 ===
 
@@ -22,6 +24,8 @@ achieved success with much lower system requirements. However, launching
 tools will have higher system requirements dependent on the specific
 tool. Consult a tool's README or CWL/WDL description when in doubt.
 
+:ref:`(back to top) <topFAQ>`
+
 
 .. _what-is-a-verified-tool-or-workflow:
 
@@ -31,6 +35,8 @@ What is a verified tool or workflow?
 A verified tool/workflow means that at least one version has been verified to be successfully ran on a platform.
 
 See :doc:`/advanced-topics/verification` for full details on this feature.
+
+:ref:`(back to top) <topFAQ>`
 
 
 What is a default version of a tool or workflow?
@@ -64,7 +70,9 @@ not limited to):
     would be equivalent to
 
     ``$ dockstore tool launch --entry quay.io/cancercollaboratory/dockstore-tool-bedgraph-bigwig --json Dockstore.json``
-4. The docker pull command in the tools search reflects the defaultversion
+4. The docker pull command in the tools search reflects the default version
+
+:ref:`(back to top) <topFAQ>`
 
 .. _what-is-an-open-tool-or-workflow:
 
@@ -80,11 +88,14 @@ Note that tool and workflow versions that do not require any file input paramete
 You can find Open Data workflows and tools by selecting the Open Data facet on the `search <https://dockstore.org/search>`_ page.
 When viewing an individual tool or workflow, you can tell which versions are Open Data on the Versions tab via the Open column.
 
+:ref:`(back to top) <topFAQ>`
+
 How should I register my work in Dockstore?
 -------------------------------------------
 
 .. include:: /getting-started/how-to-register-work.rst
-
+   
+:ref:`(back to top) <topFAQ>`
 
 How do I send private messages to administrators or report security vulnerabilities?
 ------------------------------------------------------------------------------------
@@ -104,6 +115,7 @@ The following steps can be taken to create a helpdesk ticket (also shown `here <
    Entering 5 topics and viewing 30 posts over a minimum of 10 minutes will raise your privileges. \
    You will be notified of any privilege changes to your account via the mailbox.
 
+:ref:`(back to top) <topFAQ>`
 
 How do I cite Dockstore?
 ------------------------
@@ -114,6 +126,8 @@ paper <https://dx.doi.org/10.12688/f1000research.10137.1>`__.
 For citing the actual code, we recommend looking at our Zenodo entry.
 You will find a variety of citation styles and ways to export it at
 |DOI|.
+
+:ref:`(back to top) <topFAQ>`
 
 .. _faq-header-github-integration:
 
@@ -133,6 +147,7 @@ only be associated with one account at a time. You will need to link
 with a different account for each login method or delete your account if
 you want to assign them to a new Dockstore account.
 
+:ref:`(back to top) <topFAQ>`
 
 
 What happens if I rename my GitHub repository?
@@ -151,6 +166,8 @@ will have registered the same workflow twice.
 Please note the GitHub warning: If you create a new repository under
 your account in the future, do not reuse the original name of the renamed
 repository. If you do, redirects to the renamed repository will break.
+
+:ref:`(back to top) <topFAQ>`
 
 
 .. _faq-header-permissions:
@@ -175,6 +192,8 @@ addresses of the users you wish to share with to give them permissions
 to your workflow. This is only available for hosted workflows and users
 with Google accounts linked to Terra.
 
+:ref:`(back to top) <topFAQ>`
+
 
 Why are my workflows from an organization I belong to not visible?
 ------------------------------------------------------------------
@@ -191,6 +210,8 @@ has access to them in order to mirror these restrictions on Dockstore
 itself. GitHub provides a
 `tutorial <https://help.github.com/en/articles/approving-oauth-apps-for-your-organization/>`__
 for approving third party apps access to your organization.
+
+:ref:`(back to top) <topFAQ>`
 
 Why do I get an error when I try to request a DOI?
 --------------------------------------------------
@@ -217,6 +238,8 @@ The workflow version DOI can be found on the Versions tab.
 .. figure:: /assets/images/docs/workflow-version-doi.png
    :alt: Workflow version DOI
 
+:ref:`(back to top) <topFAQ>`
+
 .. _faq-header-other:
 
 Other
@@ -230,6 +253,8 @@ for an image on Quay.io, `as an
 example <https://quay.io/repository/pancancer/pcawg-bwa-mem-workflow?tab=tags>`__.
 If you have the right permissions, you can delete some and then refresh
 a tool on Dockstore to clean-up.
+
+:ref:`(back to top) <topFAQ>`
 
 
 How do I get more space inside my CWL tool running in a container?
@@ -286,6 +311,8 @@ Also be aware that some tools will use space from your root filesystem.
 For example, Docker's storage driver and data volumes will by default
 install to and use space on your root filesystem.
 
+:ref:`(back to top) <topFAQ>`
+
 
 Do you have tips on creating Dockerfiles?
 -----------------------------------------
@@ -298,6 +325,8 @@ Do you have tips on creating Dockerfiles?
 -  do not depend on changes to ``hostname`` or ``/etc/hosts``, Docker
    will interfere with this
 -  try to keep your Docker images small
+
+:ref:`(back to top) <topFAQ>`
 
 
 Do you have tips on creating CWL files?
@@ -333,6 +362,7 @@ Additionally:
       your container. Make sure your host running Docker has sufficient
       scratch space for processing your genomics data.
 
+:ref:`(back to top) <topFAQ>`
 
 .. _why-would-i-want-to-add-a-specific-version-of-a-workflow-to-a-collection:
 
@@ -347,6 +377,8 @@ Note that the version of a workflow can be especially important when working wit
 
 In summary: you can pin either a specific version of a workflow or a workflow in general depending on what relationship you wish to express. We recommend explaining further for others in the accompanying Markdown description. 
 
+:ref:`(back to top) <topFAQ>`
+
 
 Any last tips on using Dockstore?
 ---------------------------------
@@ -360,12 +392,16 @@ Any last tips on using Dockstore?
 -  related to the two above, you can use non-standard file paths if you
    customize your registrations in the Version tab of Dockstore
 
+:ref:`(back to top) <topFAQ>`
+
 What happens if I link to a different ORCID account?
 ----------------------------------------------------
 
 `ORCID <https://orcid.org>`__ is designed to `discourage more than one account for an individual <https://support.orcid.org/hc/en-us/articles/360006971593-Do-you-have-more-than-one-account->`__. However, if you somehow end up with two ORCID accounts, publish a record from Dockstore using the first ORCID account, then relink Dockstore to the second ORCID account, you will not be able to update the original ORCID record from within Dockstore.
 
 If you run into this situation, please use the `Help Desk` link in the https://dockstore.org footer to contact the Dockstore team.
+
+:ref:`(back to top) <topFAQ>`
 
 .. |DOI| image:: https://zenodo.org/badge/DOI/10.5281/zenodo.321679.svg
    :target: https://zenodo.org/record/321679

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -310,9 +310,9 @@ Do you have tips on creating Dockerfiles?
    client/server issues, it is also not compatible with CWL)
 -  do not depend on changes to ``hostname`` or ``/etc/hosts``, Docker
    will interfere with this
--  use a well-known and secure base image such as official debian or Python images
+-  use a well-known and secure :ref:`dict parent image` such as official `debian <https://hub.docker.com/_/debian>`__ or `Python <https://hub.docker.com/_/python>`__ images
 -  try to keep your Docker images small
-   -  however, do not use alpine images, or other images that lack bash, as your base image unless you will be installing bash in the Dockerfile 
+   -  however, do not use alpine images, or other images that lack bash, as your parent image unless you will be installing bash in the Dockerfile 
   
 
 :ref:`(back to top) <topFAQ>`

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -121,7 +121,7 @@ Integration with GitHub
 ^^^^^^^^^^^^^^^^^^^^^^^
 
 What is the difference between logging in with GitHub versus logging in with Google?
------------------------------------------------------------------------------------
+-------------------------------------------------------------------------------------
 
 The intent here is that you should be able to login with either login
 method and still conveniently get into the same Dockstore account. With
@@ -312,20 +312,20 @@ Do you have tips on creating Dockerfiles?
    will interfere with this
 -  use a well-known and secure base image such as official debian or Python images
 -  try to keep your Docker images small
-  -  however, do not use alpine images, or other images that lack bash, as your base image unless you will be installing bash in the Dockerfile
-
+   -  however, do not use alpine images, or other images that lack bash, as your base image unless you will be installing bash in the Dockerfile 
+  
 
 :ref:`(back to top) <topFAQ>`
 
 How should I handle large reference files when designing workflows and Dockerfiles?
 -----------------------------------------------------------------------------------
 Generally speaking, you can choose to either "package" reference files in your Docker image, or you can treat them as "inputs" so they can be stage outside and mounted into the running container. Both of these approaches will work on a variety of backends, but there are some backends in which one option might be better than the other.
+
+
       - if you are running on a backend that can mount files into your containers quickly, such as a local installation of miniwdl, and your input files are available without having to download them, is probably best to treat reference files as an input
       - if you are running your workflow on a backend that needs to download input files (such as Terra), and you need to put those reference files into many instances of a Docker container (such as if you are using scattered tasks), it is probably best to bake your reference files into the Dockerfile so they are immediately available in the Docker image
-      - if using Terra, you can make use of `reference disks <https://support.terra.bio/hc/en-us/articles/360056384631-Overview-Reference-Disks-in-Terra>` to easily bring human references into your Docker image 
-      -  the ``$TMPDIR`` variable can be used as a scratch space inside
-      your container. Make sure your host running Docker has sufficient
-      scratch space for processing your genomics data.
+      - if using Terra, you can make use of `reference disks <https://support.terra.bio/hc/en-us/articles/360056384631-Overview-Reference-Disks-in-Terra>`__ to easily bring human references into your Docker image 
+      -  the ``$TMPDIR`` variable can be used as a scratch space inside your container. Make sure your host running Docker has sufficient scratch space for processing your genomics data.
 
 Do you have tips on creating workflows?
 ---------------------------------------

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -13,6 +13,10 @@ For questions relating to the Dockstore CLI, please see :doc:`Dockstore CLI FAQ 
 General Dockstore Questions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+How do I use workflows that I find on Dockstore? 
+------------------------------------------------
+If you want to run the workflow locally, you can :doc:`use the Dockstore CLI to download and run the workflow </launch-with/launch>`. Alternatively, you can run the workflow using a cloud platform by clicking the "launch with" button on the right side of the workflow entry.
+
 .. _what-is-a-verified-tool-or-workflow:
 
 What is a verified tool or workflow?
@@ -319,7 +323,7 @@ Do you have tips on creating Dockerfiles?
 
 How should I handle large reference files when designing workflows and Dockerfiles?
 -----------------------------------------------------------------------------------
-Generally speaking, you can choose to either "package" reference files in your Docker image, or you can treat them as "inputs" so they can be stage outside and mounted into the running container. We generally recommend having them serve as inputs.
+Generally speaking, you can choose to either "package" reference files in your Docker image, or you can treat them as "inputs" so they can be staged outside and mounted into the running container. We generally recommend having them serve as inputs.
 
 :ref:`(back to top) <topFAQ>`
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -325,6 +325,8 @@ Do you have tips on creating Dockerfiles?
 -  do not depend on changes to ``hostname`` or ``/etc/hosts``, Docker
    will interfere with this
 -  try to keep your Docker images small
+  -  however, do not use alpine images, or other images that lack bash, as your base image unless you will be installing bash in the Dockerfile (WDL forces /bin/bash as an entrypoint meaning that images that only have sh will fail if used in a WDL workflow)
+
 
 :ref:`(back to top) <topFAQ>`
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -120,8 +120,8 @@ You will find a variety of citation styles and ways to export it at
 Integration with GitHub
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-What is the difference between logging in with GitHub or logging in with Google?
---------------------------------------------------------------------------------
+What is the difference between logging in with GitHub versus logging in with Google?
+-----------------------------------------------------------------------------------
 
 The intent here is that you should be able to login with either login
 method and still conveniently get into the same Dockstore account. With

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -13,20 +13,6 @@ For questions relating to the Dockstore CLI, please see :doc:`Dockstore CLI FAQ 
 General Dockstore Questions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-What environment do you test tools in?
---------------------------------------
-
-Typically, we test running tools in Ubuntu Linux 16.04 LTS on VMs in
-`OpenStack <https://www.openstack.org/>`__ with 8 vCPUs and 96 GB of RAM
-and above. We've also begun testing on Ubuntu 18.04 LTS and so far it's
-been successful. If you are only listing and editing tools, we have
-achieved success with much lower system requirements. However, launching
-tools will have higher system requirements dependent on the specific
-tool. Consult a tool's README or CWL/WDL/Nextflow description when in doubt.
-
-:ref:`(back to top) <topFAQ>`
-
-
 .. _what-is-a-verified-tool-or-workflow:
 
 What is a verified tool or workflow?

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -22,7 +22,7 @@ and above. We've also begun testing on Ubuntu 18.04 LTS and so far it's
 been successful. If you are only listing and editing tools, we have
 achieved success with much lower system requirements. However, launching
 tools will have higher system requirements dependent on the specific
-tool. Consult a tool's README or CWL/WDL description when in doubt.
+tool. Consult a tool's README or CWL/WDL/Nextflow description when in doubt.
 
 :ref:`(back to top) <topFAQ>`
 
@@ -324,45 +324,46 @@ Do you have tips on creating Dockerfiles?
    client/server issues, it is also not compatible with CWL)
 -  do not depend on changes to ``hostname`` or ``/etc/hosts``, Docker
    will interfere with this
+-  use a well-known and secure base image such as official debian or Python images
 -  try to keep your Docker images small
-  -  however, do not use alpine images, or other images that lack bash, as your base image unless you will be installing bash in the Dockerfile (WDL forces /bin/bash as an entrypoint meaning that images that only have sh will fail if used in a WDL workflow)
+  -  however, do not use alpine images, or other images that lack bash, as your base image unless you will be installing bash in the Dockerfile
 
 
 :ref:`(back to top) <topFAQ>`
 
+How should I handle large reference files when designing workflows and Dockerfiles?
+-----------------------------------------------------------------------------------
+Generally speaking, you can choose to either "package" reference files in your Docker image, or you can treat them as "inputs" so they can be stage outside and mounted into the running container. Both of these approaches will work on a variety of backends, but there are some backends in which one option might be better than the other.
+      - if you are running on a backend that can mount files into your containers quickly, such as a local installation of miniwdl, and your input files are available without having to download them, is probably best to treat reference files as an input
+      - if you are running your workflow on a backend that needs to download input files (such as Terra), and you need to put those reference files into many instances of a Docker container (such as if you are using scattered tasks), it is probably best to bake your reference files into the Dockerfile so they are immediately available in the Docker image
+      - if using Terra, you can make use of `reference disks <https://support.terra.bio/hc/en-us/articles/360056384631-Overview-Reference-Disks-in-Terra>` to easily bring human references into your Docker image 
+      -  the ``$TMPDIR`` variable can be used as a scratch space inside
+      your container. Make sure your host running Docker has sufficient
+      scratch space for processing your genomics data.
 
-Do you have tips on creating CWL files?
+Do you have tips on creating workflows?
 ---------------------------------------
 
-When writing CWL tools and workflows, there are a few common workarounds
-that can be used to deal with the restrictions that CWL places on the
-use of docker. These include:
+When writing workflows, there are a few common workarounds
+that can be used to deal with the restrictions that workflow languages such as CWL and WDL place on the
+use of Docker. These include:
 
 * cwltool (which we use to run tools) is restrictive and locks down much of ``/`` as read only, use the current working directory or $TMPDIR for file writes 
 
 * You can also use `Docker volumes <https://docs.docker.com/engine/reference/builder/#/volume>`__ in your Dockerfile to specify additional writeable directories
 
-* Do not rely on the hostname inside a container, Docker dynamically generates this when starting containers
+* Do not rely on the hostname inside a container; Docker dynamically generates this when starting containers
+
+* Do not rely on an entrypoint inside a container; workflow executors tend to override custom entrypoints with /bin/bash 
 
 Additionally:
 
--  you need to "collect" output from your tools/workflows inside docker
-   and drop them into the current working directory in order for CWL to
-   "find" them and pull them back outside of the container
+-  in order for the workflow executor to "find" your outputs and pull them back outside the container, you may want to "collect" output from your tools/workflows inside Docker and drop them into the current working directory
 -  related to this, it's often times easiest to write a simple wrapper
    script that maps the command line arguments specified by CWL to
    however your tool expects to be parameterized. This script can handle
    moving output to the current working directory and renaming if need
    be
--  genomics workflows work with large data files, this can have a few
-   ramifications:
-
-   -  do not "package" large data reference files in your Docker image.
-      Instead, treat them as "inputs" so they can be staged outside and
-      mounted into the running container
-   -  the ``$TMPDIR`` variable can be used as a scratch space inside
-      your container. Make sure your host running Docker has sufficient
-      scratch space for processing your genomics data.
 
 :ref:`(back to top) <topFAQ>`
 
@@ -386,11 +387,12 @@ Any last tips on using Dockstore?
 ---------------------------------
 
 -  the Dockstore CLI uses ``./datastore`` in the working directory for
-   temp files so if you're processing large files make sure this
+   temp files, so if you're processing large files, make sure this
    partition hosting the current directory is large.
 -  you can use a single Docker image with multiple tools, each of them
    registered via a different CWL
--  you can use a Git repository with multiple CWL files
+-  you can also use a single Docker image with multiple workflows
+-  you can use a Git repository with multiple workflow files
 -  related to the two above, you can use non-standard file paths if you
    customize your registrations in the Version tab of Dockstore
 

--- a/docs/getting-started/github-apps/github-apps-troubleshooting-tips.rst
+++ b/docs/getting-started/github-apps/github-apps-troubleshooting-tips.rst
@@ -173,17 +173,24 @@ A new separate workflow/tool will be registered if the original name isn't inclu
 How can I convert my entire existing workflow/tool at once?
 -------------------------------------------------------------
 Currently you cannot convert all existing branches/versions at once. You must add a .dockstore.yml to each branch in order for the GitHub app
-automatically detect and sync changes with the corresponding version on Dockstore.
+automatically detect and sync changes with the corresponding version on Dockstore. A side effect of this is that, unless you edit tagged commits to include .dockstore.yml files, old releases created prior to you creating a .dockstore.yml will not be selectable in Dockstore.
 
 If you have a .dockstore.yml file in your master or develop branches on GitHub, any new branches you create from these as your template
-will have a  .dockstore.yml.
+will have a .dockstore.yml, as will future releases based on master or develop.
 
 :ref:`(back to top) <topGHAFAQ>`
 
 
 Why are only some branches appearing on my workflow/tool?
 ----------------------------------------------------------
-The Dockstore GitHub App is currently unable to parse branches that use special characters besides numerical digits, non-leading dashes, forward slashes, periods, and underscores. "Special characters" includes alphabetical characters with accents, tildes, circumflexes, umlauts, or non-English letters such as ß and ø. These limitations are stricter than what GitHub itself allows. As a result, if you have a GitHub branch named something like `Ó-Fearghail`, `branch-with-{curly-braces}`, or `Robert');-DROP-TABLE-Students;`, that branch will not appear on Dockstore. If you check the Dockstore GitHub App logs, you'll see these branches throw an error such as `Reference refs/heads/branch-with-{curly-braces} is not of the valid form`. 
+Any branches that do not have a .dockstore.yml file will not appear on your workflow/tool entry. If the branches you expect to see do indeed have properly formatted .dockstore.yml file, the culprit might be the name of the branches: The Dockstore GitHub App currently supports only the following special characters in branch names:
+* numerical digits
+* non-leading dashes
+* forward slashes
+* periods
+* underscores.
+
+Branches which contain other special characters, including alphabetical characters with accents, tildes, circumflexes, umlauts, or non-English letters such as ß and ø, cannot be parsed by the Dockstore GitHub App and will not show up. If you check the Dockstore GitHub App logs, you'll see these branches throw an error such as `Reference refs/heads/Robert');-DROP-TABLE-Students; is not of the valid form`. 
 
 However, even if you have branches with unsupported names, other branches with names like `main` and `develop` will continue to update on Dockstore as normal. The public view of your published entry will not show any errors -- it will simply not show the branches with unsupported names.
 

--- a/docs/getting-started/github-apps/github-apps-troubleshooting-tips.rst
+++ b/docs/getting-started/github-apps/github-apps-troubleshooting-tips.rst
@@ -124,17 +124,17 @@ Navigate to the ``/my-workflows`` (or ``/my-tools``) page.
 Expand the GitHub account that the repository belongs to on the left hand side. Then click on the bottom where it says ``Apps Logs``.
 
 .. image:: /assets/images/docs/github-app-logs-button.png
-   :width: 30 %
+   :width: 40 %
 
 Once loaded, the following window will be displayed.
 
 .. image:: /assets/images/docs/github-app-logs-window.png
-   :width: 60 %
+   :width: 80 %
 
 Here you can view all the GitHub app events Dockstore is aware of and whether they failed or were successful. If there was a failure, you can expand that row and view the error message as shown below.
 
 .. image:: /assets/images/docs/github-app-logs-error-message.png
-   :width: 60 %
+   :width: 80 %
 
 In the case shown above, the error message is from parsing the following .dockstore.yml file.
 

--- a/docs/getting-started/github-apps/github-apps-troubleshooting-tips.rst
+++ b/docs/getting-started/github-apps/github-apps-troubleshooting-tips.rst
@@ -129,10 +129,12 @@ Expand the GitHub account that the repository belongs to on the left hand side. 
 Once loaded, the following window will be displayed.
 
 .. image:: /assets/images/docs/github-app-logs-window.png
+   :width: 60 %
 
 Here you can view all the GitHub app events Dockstore is aware of and whether they failed or were successful. If there was a failure, you can expand that row and view the error message as shown below.
 
 .. image:: /assets/images/docs/github-app-logs-error-message.png
+   :width: 60 %
 
 In the case shown above, the error message is from parsing the following .dockstore.yml file.
 

--- a/docs/getting-started/github-apps/github-apps-troubleshooting-tips.rst
+++ b/docs/getting-started/github-apps/github-apps-troubleshooting-tips.rst
@@ -183,21 +183,5 @@ will have a .dockstore.yml, as will future releases based on master or develop.
 :ref:`(back to top) <topGHAFAQ>`
 
 
-Why are only some branches appearing on my workflow/tool?
-----------------------------------------------------------
-Any branches that do not have a .dockstore.yml file will not appear on your workflow/tool entry. If the branches you expect to see do indeed have properly formatted .dockstore.yml file, the culprit might be the name of the branches: The Dockstore GitHub App currently supports only the following special characters in branch names:
-* numerical digits
-* non-leading dashes
-* forward slashes
-* periods
-* underscores.
-
-Branches which contain other special characters, including alphabetical characters with accents, tildes, circumflexes, umlauts, or non-English letters such as ß and ø, cannot be parsed by the Dockstore GitHub App and will not show up. If you check the Dockstore GitHub App logs, you'll see these branches throw an error such as ``Reference refs/heads/Robert');-DROP-TABLE-Students; is not of the valid form``. 
-
-However, even if you have branches with unsupported names, other branches with names like `main` and `develop` will continue to update on Dockstore as normal. The public view of your published entry will not show any errors -- it will simply not show the branches with unsupported names.
-
-:ref:`(back to top) <topGHAFAQ>`
-
-
 .. discourse::
     :topic_identifier: 6485

--- a/docs/getting-started/github-apps/github-apps-troubleshooting-tips.rst
+++ b/docs/getting-started/github-apps/github-apps-troubleshooting-tips.rst
@@ -20,7 +20,9 @@ This requires the addition of a .dockstore.yml file to your repository on GitHub
 This file contains information that Dockstore will use to setup
 the corresponding workflow/tool entry on Dockstore. Branches that do not have a .dockstore.yml file, or that are filtered out via the filter feature, will not be synchronized.
 
-You can read more about it at :doc:`/getting-started/github-apps/github-apps`. :ref:`(back to top) <topGHAFAQ>`
+You can read more about it at :doc:`/getting-started/github-apps/github-apps`. 
+
+:ref:`(back to top) <topGHAFAQ>`
 
 How does this change my development flow?
 -------------------------------------------
@@ -31,7 +33,9 @@ Therefore, as long as your workflow is already registered on Dockstore and your 
 
 You can use filters in a .dockstore.yml to avoid generating a corresponding workflow-version on Dockstore.
 
-*Note:* If you want to edit version information, such as workflow path, you will have to update the .dockstore.yml file directly on the corresponding GitHub branch. For example, if develop has a .dockstore.yml that points to my_workflow.wdl, but my_workflow.wdl is moved to another path on the branch develop-but-better, then the .dockstore.yml on develop-but-better will need to point to the new location of my_workflow.wdl. :ref:`(back to top) <topGHAFAQ>`
+*Note:* If you want to edit version information, such as workflow path, you will have to update the .dockstore.yml file directly on the corresponding GitHub branch. For example, if develop has a .dockstore.yml that points to my_workflow.wdl, but my_workflow.wdl is moved to another path on the branch develop-but-better, then the .dockstore.yml on develop-but-better will need to point to the new location of my_workflow.wdl. 
+
+:ref:`(back to top) <topGHAFAQ>`
 
 .. _Check GitHub App installation on repository:
 
@@ -41,11 +45,15 @@ Go to your repo on GitHub and click the Settings tab. On the left hand side unde
 
 .. image:: /assets/images/docs/github-repo-settings.png
 
-If you're checking if the GitHub App was installed on a repository of an organization, you may not have access to this page if you are not an administrator of your GitHub organization, :ref:`but you may still be able to see if it installed. <view github app permissions hack>` :ref:`(back to top) <topGHAFAQ>`
+If you're checking if the GitHub App was installed on a repository of an organization, you may not have access to this page if you are not an administrator of your GitHub organization, :ref:`but you may still be able to see if it installed. <view github app permissions hack>` 
+
+:ref:`(back to top) <topGHAFAQ>`
 
 How do I configure the GitHub App across multiple repositories?
 ------------------------------------------------------------------
-GitHub Apps can be installed on either an a user level, or an organizational level. If you installed the app for your own repositories that are not in an organization, you will be able to verify the Dockstore GitHub App is installed by clicking "Applications" in the left menu in your GitHub settings. Our app, along with any others you may have installed, will be there. Clicking the "configure" button will allow you to adjust which repos the app has access to. :ref:`(back to top) <topGHAFAQ>`
+GitHub Apps can be installed on either an a user level, or an organizational level. If you installed the app for your own repositories that are not in an organization, you will be able to verify the Dockstore GitHub App is installed by clicking "Applications" in the left menu in your GitHub settings. Our app, along with any others you may have installed, will be there. Clicking the "configure" button will allow you to adjust which repos the app has access to. 
+
+:ref:`(back to top) <topGHAFAQ>`
 
 .. _view github app permissions hack:
 
@@ -178,6 +186,8 @@ Why are only some branches appearing on my workflow/tool?
 The Dockstore GitHub App is currently unable to parse branches that use special characters besides numerical digits, non-leading dashes, forward slashes, periods, and underscores. "Special characters" includes alphabetical characters with accents, tildes, circumflexes, umlauts, or non-English letters such as ß and ø. These limitations are stricter than what GitHub itself allows. As a result, if you have a GitHub branch named something like `Ó-Fearghail`, `branch-with-{curly-braces}`, or `Robert');-DROP-TABLE-Students;`, that branch will not appear on Dockstore. If you check the Dockstore GitHub App logs, you'll see these branches throw an error such as `Reference refs/heads/branch-with-{curly-braces} is not of the valid form`. 
 
 However, even if you have branches with unsupported names, other branches with names like `main` and `develop` will continue to update on Dockstore as normal. The public view of your published entry will not show any errors -- it will simply not show the branches with unsupported names.
+
+:ref:`(back to top) <topGHAFAQ>`
 
 
 .. discourse::

--- a/docs/getting-started/github-apps/github-apps-troubleshooting-tips.rst
+++ b/docs/getting-started/github-apps/github-apps-troubleshooting-tips.rst
@@ -192,7 +192,7 @@ Any branches that do not have a .dockstore.yml file will not appear on your work
 * periods
 * underscores.
 
-Branches which contain other special characters, including alphabetical characters with accents, tildes, circumflexes, umlauts, or non-English letters such as ß and ø, cannot be parsed by the Dockstore GitHub App and will not show up. If you check the Dockstore GitHub App logs, you'll see these branches throw an error such as `Reference refs/heads/Robert');-DROP-TABLE-Students; is not of the valid form`. 
+Branches which contain other special characters, including alphabetical characters with accents, tildes, circumflexes, umlauts, or non-English letters such as ß and ø, cannot be parsed by the Dockstore GitHub App and will not show up. If you check the Dockstore GitHub App logs, you'll see these branches throw an error such as ``Reference refs/heads/Robert');-DROP-TABLE-Students; is not of the valid form``. 
 
 However, even if you have branches with unsupported names, other branches with names like `main` and `develop` will continue to update on Dockstore as normal. The public view of your published entry will not show any errors -- it will simply not show the branches with unsupported names.
 


### PR DESCRIPTION
Builds upon #247. This is bigger than #247, so it might be best to aim this one at 1.15?

* ~Move~ Delete environment question from main FAQ ~to advanced CLI FAQ~
  * A new user not very familiar with Dockstore might go the main FAQ, see in the first entry that we use 96 gigs of RAM to test tools, incorrectly conclude that's what they need to do anything with tools, and write off Dockstore as something for people with very beefy machines
* How to handle big reference files gets its own answer now, ~and that answer has changed because it turns out localizing [a 14 GB reference genome](https://console.cloud.google.com/storage/browser/_details/topmed_workflow_testing/tb/ref/index_decontamination_ref_output/Ref.remove_contam.tar;tab=live_object) into [thousands of Docker images](https://github.com/aofarrel/SRANWRP/blob/main/inputs/tb_accessions/tb_a3/tb_a3.txt) via [a surprisingly slow gsutil command](https://support.terra.bio/hc/en-us/community/posts/10732090690843-Switch-Localization-Delocalization-From-gsutil-to-gcloud-storage) is kind of awful~ this contradicts what we said on the FAIR page and has been removed
* Pull back on the CWL focus
* Add glossary entry for parent image
* Tweak sizes of screenshot images in the how-to-view-logs question
* Warn against using alpine as a parent image
  * Cromwell (and miniwdl, I think?) forces /bin/bash as an entrypoint so they don't work with WDLs
* Modify an answer that implied you cannot grab outputs that aren't in the workdir
* Small wording/punctuation changes

-----------------------------------------------------

New changes since review on previous PR:

* Add "how do I use workflows" to general FAQ (we don't seem to have a generalized "launch with cloud partners" page so we're kind of counting on users having a platform in mind and clicking it in the sidebar)
* Remove regex question thanks to https://github.com/dockstore/dockstore/pull/5354
* Remove "what environment do you test on" question
* Large reference files question still acknowledges you can put inputs into the Dockerfile, but recommends the inputs method -- * we can revisit that later, but it's important to not contradict the FAIR page
* Stage/Staging typo fixed
* Ubuntu 22.04 instead of 18.04