### PR TITLE
Update copyright notice to include range ending in current year

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,8 +19,10 @@
 
 # -- Project information -----------------------------------------------------
 
+import datetime
+
 project = u'Dockstore'
-copyright = u'2021, OICR, and UCSC'
+copyright = f'2021-{datetime.date.today().year}, OICR, and UCSC'
 author = u'OICR, UCSC'
 
 # The short X.Y version


### PR DESCRIPTION
**Description**
Right now, the following copyright notice appears at the end of each of our documentation pages:
```
© Copyright 2021, OICR, and UCSC.
```
2021 was years ago, so the above notice could make the pages feel stale.

This PR replaces converts the year to a range, starting in 2021 and ending at the current year:
```
© Copyright 2021-2024, OICR, and UCSC.
```
Ah, so much fresher!

The use of a range seems common, and as I understand it, the requirement is that the first year of publication should appear in the copyright notice (in this case, as the first year of the range).  Disclaimer: I am not a lawyer, and this is not legal advice.

Charles found this list of big org copyright notices:
https://www.termsfeed.com/blog/sample-copyright-notices/

I'd argue for removing the punctuation, although that's not in the PR right now.

**Issue**
None.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If the PR has any new pages, only **AFTER** the PR is approved by all reviewers, generate a new discourse topic, by running the action at https://github.com/dockstore/dockstore-documentation/actions/workflows/add-discourse-topic.yml. Otherwise we may end up with orphaned topics, which would need manual management.
