### PR TITLE
SEAB-6142: Split Up Documentation Build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,39 +1,15 @@
 version: 2.1
 jobs:
-  setup:
-    docker:
-      - image: python:3.7
-    steps:
-      - checkout
-      - jq/install
-      - run:
-          name: Install dependencies
-          command: pip install -r requirements.txt
-      - run:
-          name: Make html
-          command: cd docs && make html
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .
   test:
     docker:
       - image: python:3.7
     steps:
-      - attach_workspace:
-          at: .
-      - run:
-          name: Verify dictionary file was generated
-          command: cd docs && test -f dictionary.rst
-      - run:
-          name: Link check
-          command: cd docs && make linkcheck
+      - basic_test
   topic:
     docker:
       - image: python:3.7
     steps:
-      - attach_workspace:
-          at: .
+      - basic_test
       - run:
           name: Discourse Topic Check
           command: |
@@ -44,10 +20,22 @@ workflows:
   version: 2.1
   build:
     jobs:
-      - setup
-      - test:
-          requires:
-            - setup
-      - topic:
-          requires:
-            - setup
+      - test
+      - topic
+commands:
+  basic_test:
+    steps:
+      - checkout
+      - jq/install
+      - run:
+          name: Install dependencies
+          command: pip install -r requirements.txt
+      - run:
+          name: Make html
+          command: cd docs && make html
+      - run:
+          name: Verify dictionary file was generated
+          command: cd docs && test -f dictionary.rst
+      - run:
+          name: Link check
+          command: cd docs && make linkcheck

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - run:
           name: Discourse Topic Check
           command: |
-            bash discourse-topic-check.sh
+            bash ./discourse-topic-check.sh
 orbs:
   jq: circleci/jq@2.2.0
 workflows:
@@ -33,4 +33,6 @@ workflows:
   build:
     jobs:
       - test
-      - topic
+      - topic:
+          requires:
+            - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2.1
 jobs:
-  test:
+  setup:
     docker:
       - image: python:3.7
     steps:
@@ -12,6 +12,16 @@ jobs:
       - run:
           name: Make html
           command: cd docs && make html
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+  test:
+    docker:
+      - image: python:3.7
+    steps:
+      - attach_workspace:
+          at: .
       - run:
           name: Verify dictionary file was generated
           command: cd docs && test -f dictionary.rst
@@ -22,17 +32,22 @@ jobs:
     docker:
       - image: python:3.7
     steps:
+      - attach_workspace:
+          at: .
       - run:
           name: Discourse Topic Check
           command: |
-            bash ./discourse-topic-check.sh
+            bash discourse-topic-check.sh
 orbs:
   jq: circleci/jq@2.2.0
 workflows:
   version: 2.1
   build:
     jobs:
-      - test
+      - setup
+      - test:
+          requires:
+            - setup
       - topic:
           requires:
-            - test
+            - setup

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,10 @@ jobs:
       - run:
           name: Link check
           command: cd docs && make linkcheck
+  topic:
+    docker:
+      - image: python:3.7
+    steps:
       - run:
           name: Discourse Topic Check
           command: |
@@ -29,3 +33,4 @@ workflows:
   build:
     jobs:
       - test
+      - topic


### PR DESCRIPTION
**Description**
New discourse topics are only added to documentation pages after approval, which can cause build failures. 

By splitting the discourse topic check into a separate build job, each change to the documentation will trigger two CircleCI checks: "test" covers the build up to and excluding the discourse topic, while "topic" checks the entire build including the discourse topic. 

The goal is that, when adding to the documentation, it should be easier to identify whether or not the rest of the build succeeded (i.e. at least 1/2 checks passed).

**Issue**
[SEAB-6142](https://ucsc-cgl.atlassian.net/browse/SEAB-6142?atlOrigin=eyJpIjoiMzc1NWQ3NDljYWNlNDNiMWE2MDQxNjYzYTQ5YzJlMTQiLCJwIjoiaiJ9)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If the PR has any new pages, only **AFTER** the PR is approved by all reviewers, generate a new discourse topic, by running the action at https://github.com/dockstore/dockstore-documentation/actions/workflows/add-discourse-topic.yml. Otherwise we may end up with orphaned topics, which would need manual management.


[SEAB-6142]: https://ucsc-cgl.atlassian.net/browse/SEAB-6142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ