### PR TITLE
SEAB-5124: Adjust notebooks documentation

### DIFF
--- a/docs/_attic/glossary_entries.py
+++ b/docs/_attic/glossary_entries.py
@@ -249,7 +249,7 @@ Elwazi = GlossEntry("eLwazi",
 
 Entry = GlossEntry("entry", 
 	acronym_full="", 
-	definition="Shorthand for a [tool] or [workflow] that has been registered on Dockstore.", 
+	definition="Shorthand for a [tool], [workflow], [notebook], or service that has been registered on Dockstore.",
 	furtherreading="", 
 	institute="Dockstore", 
 	pronunciation='')
@@ -476,6 +476,13 @@ NIH = GlossEntry("NIH",
 	definition="An American government institution, part of the Department of Health and Human Services (HHS), that engages in medical research.", 
 	furtherreading="https://www.nih.gov/", 
 	institute="", 
+	pronunciation="")
+
+notebook = GlossEntry("notebook",
+	acronym_full="",
+	definition="An interactive document, made up of \"cells\" containing code, text, and images, authored and executed in a browser-based programming environment.  Project [Jupyter] popularized Python-based notebooks and maintains related specifications and software.",
+	furtherreading="/getting-started/getting-started-with-notebooks",
+	institute="",
 	pronunciation="")
 
 OICR = GlossEntry("OICR", 

--- a/docs/_attic/glossary_entries_list_dynamic.txt
+++ b/docs/_attic/glossary_entries_list_dynamic.txt
@@ -66,6 +66,7 @@ NFL
 NHGRI
 NHLBI
 NIH
+notebook
 OICR
 ORCID
 organization

--- a/docs/advanced-topics/metrics.rst
+++ b/docs/advanced-topics/metrics.rst
@@ -152,3 +152,6 @@ The curl command results in something like:
    }'
 
 If it was submitted successfully, you should receive a ``204`` response code. 
+
+.. discourse::
+    :topic_identifier: 7983

--- a/docs/assets/templates/notebooks/notebooks.rst
+++ b/docs/assets/templates/notebooks/notebooks.rst
@@ -1,6 +1,5 @@
 .dockstore.yml for Notebooks Templates (version 1.2)
 ====================================================
-.. note:: Support for notebooks is in preview mode.
 
 Two templates are provided here, one for you to quickly copy-paste into your repository, and one with a complete explanation of the possible fields and values you can use.
 

--- a/docs/getting-started/getting-started-with-notebooks.rst
+++ b/docs/getting-started/getting-started-with-notebooks.rst
@@ -133,3 +133,6 @@ When viewing a public notebook on Dockstore, you can launch the notebook into Go
 
 .. figure:: /assets/images/docs/launch-with-google-colab.png
 
+
+.. discourse::
+    :topic_identifier: 7984

--- a/docs/getting-started/getting-started-with-notebooks.rst
+++ b/docs/getting-started/getting-started-with-notebooks.rst
@@ -5,8 +5,6 @@ Notebooks
    :local:
    :depth: 2
 
-.. note:: Dockstore Notebooks is currently in preview mode. Also note that the screenshots below were taken on our staging site.
-
 Tutorial Goals
 --------------
 
@@ -16,7 +14,7 @@ Tutorial Goals
 - Publish your notebook to Dockstore
 
 Notebooks are documents that can include code, text, images, and other media resources. They can be executed in notebook environments like Google Colab and JupyterLab.
-This document will outline what is needed to register, update, and publish a notebook onto Dockstore. Please keep in mind that notebook functionality is currently in preview mode.
+This document outlines how to register, update, and publish a notebook on Dockstore.
 
 Overview
 --------
@@ -89,8 +87,6 @@ Within this, you can to specify the ``format`` and ``language`` of the notebook.
 
 Next, you need to specify the absolute path to the notebook file in the Git repository using the ``path`` key.
 
-Finally, you must set ``publish: true`` to publish your notebook in order for you to be able to view your notebook in preview mode. In the future, we will implement a My Notebooks page where you can view your unpublished notebooks.
-
 Registering Your Notebook
 -------------------------
 .. include:: /getting-started/github-apps/note--registration.rst
@@ -137,26 +133,3 @@ When viewing a public notebook on Dockstore, you can launch the notebook into Go
 
 .. figure:: /assets/images/docs/launch-with-google-colab.png
 
-Using the Notebooks Feature Flag
---------------------------------
-
-There is a ``notebooks`` feature flag that can be used to explore Dockstore Notebooks features that are in development.
-
-.. warning:: The features hidden behind this flag may not be fully functional, but using the flag offers you a preview of the features to come.
-
-To use the ``notebooks`` feature flag, append ``notebooks`` to the Dockstore URL as a query parameter. You only need to do this once, unless you refresh/close your browser.
-
-For example, if you're on the https://dockstore.org page, append ``notebooks`` such that it looks like this: https://dockstore.org?notebooks.
-
-If you're on a page that already contains query parameters, indicated by the presence of a question mark, append ``notebooks`` to the URL using an ampersand. For example, if you're on the https://dockstore.org/starred?tab=workflows page, append ``notebooks`` such that it looks like https://dockstore.org/starred?tab=workflows&notebooks.
-
-After applying the notebooks feature flag, Dockstore Notebooks features will appear throughout the site, marked with a warning banner.
-
-.. figure:: /assets/images/docs/notebooks-warning-banner.png
-
-Features that are activated with the feature flag:
-
-- Notebooks component is displayed on the My Dashboard page for a logged-in user
-- Notebooks tab is displayed on the My Starred page for a logged in user
-- Notebooks tab is displayed on the Search page
-- Notebooks link is displayed on the Sitemap

--- a/docs/getting-started/github-apps/snippet--installation.rst
+++ b/docs/getting-started/github-apps/snippet--installation.rst
@@ -1,6 +1,4 @@
-Installing the GitHub App is simple. Navigate to ``/my-tools``, ``/my-workflows``, or ``/my-services`` by navigating to My Dashboard then selecting the desired option in the left sidebar. In these screenshots, we will go via ``/my-tools``, but the process is essentially the same for any of the other options.
-
-.. note:: Since Dockstore Notebooks is still in preview mode, it does not have a dedicated ``/my-notebooks`` page yet. To register a notebook, navigate to ``/my-workflows`` in the step above. 
+Installing the GitHub App is simple. Navigate to ``/my-tools``, ``/my-workflows``, ``/my-notebooks``, or ``/my-services`` by navigating to My Dashboard then selecting the desired option in the left sidebar. In these screenshots, we will go via ``/my-tools``, but the process is essentially the same for any of the other options.
 
 .. image:: /assets/images/docs/my-dashboard-sidebar.png  
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,9 +44,9 @@ Getting Started
     5. :doc:`Register a tool on Dockstore <getting-started/dockstore-tools>`
     6. :doc:`Register a workflow on Dockstore <getting-started/dockstore-workflows>`
     7. :doc:`Hosted tools and workflows <getting-started/hosted-tools-and-workflows>`
+* :doc:`Notebooks <getting-started/getting-started-with-notebooks>`
 * :doc:`Services (preview) <getting-started/getting-started-with-services>`
-* :doc:`Notebooks (preview) <getting-started/getting-started-with-notebooks>`
-* :doc:`Registering workflows with the Dockstore GitHub App <getting-started/github-apps/github-apps-landing-page>`
+* :doc:`Registering tools, workflows, notebooks, and services with the Dockstore GitHub App <getting-started/github-apps/github-apps-landing-page>`
 
 .. toctree::
    :caption: Getting Started (Tutorial)

--- a/no-discourse-topic-required.txt
+++ b/no-discourse-topic-required.txt
@@ -7,6 +7,7 @@ docs/advanced-topics/best-practices/best-practices-intro.rst
 docs/advanced-topics/best-practices/sample-parameter-files-intro.rst
 docs/advanced-topics/legacy/table--legtool-vs-ghatool.rst
 docs/advanced-topics/naming-workflows.rst
+docs/assets/templates/notebooks/notebooks.rst
 docs/assets/templates/tools/tools.rst
 docs/assets/templates/workflows/workflows.rst
 docs/getting-started/adding-a-test-parameter-file.rst


### PR DESCRIPTION
**Description**
This PR makes some initial, basic, relatively non-controversial changes to the docs for the 1.15 notebook release:

1. Adds a "notebook" entry to the Dockstore dictionary.
2. Removes references to the notebooks feature flag and preview. 
3. Modifies some adjacent text to tighten and add "notebook" to the list of entry types.
 
More substantial changes are forthcoming in subsequent PRs.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-5124 (best match)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If the PR has any new pages, only **AFTER** the PR is approved by all reviewers, generate a new discourse topic, by running the action at https://github.com/dockstore/dockstore-documentation/actions/workflows/add-discourse-topic.yml. Otherwise we may end up with orphaned topics, which would need manual management.
