### PR TITLE
Update Python version to 3.9 for all jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
       - basic_test
   topic:
     docker:
-      - image: python:3.7
+      - image: python:3.9
     steps:
       - basic_test
       - run:


### PR DESCRIPTION
**Description**
See [SEAB-6142: Split Up Documentation Build](https://github.com/dockstore/dockstore-documentation/commit/4a8ef4299776292345be675cab9313de05b85806#) for the original merge. The Python version for the `topic` job was not properly updated to 3.9 as per a [previous commit](https://github.com/dockstore/dockstore-documentation/commit/96e946c8a6f96a839e5470d025ca7ca45b616cf6), which caused a check to fail.

Updating all Python versions to 3.9 should fix the inconsistency and pass the checks.

**Issue**
[Ticket (SEAB-6142)](https://ucsc-cgl.atlassian.net/browse/SEAB-6142?atlOrigin=eyJpIjoiYmZmNTQwMWYxZTlkNDRlY2E2M2MwN2M3ZGIzYzJlYjkiLCJwIjoiaiJ9)
[Original PR](https://github.com/dockstore/dockstore-documentation/pull/258)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If the PR has any new pages, only **AFTER** the PR is approved by all reviewers, generate a new discourse topic, by running the action at https://github.com/dockstore/dockstore-documentation/actions/workflows/add-discourse-topic.yml. Otherwise we may end up with orphaned topics, which would need manual management.
