### PR TITLE
SEAB-3518: added line regarding requester pays in the FAQ

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -78,7 +78,9 @@ Note that tool and workflow versions that do not require any file input paramete
 You can find Open Data workflows and tools by selecting the Open Data facet on the `search <https://dockstore.org/search>`_ page.
 When viewing an individual tool or workflow, you can tell which versions are Open Data on the Versions tab via the Open column.
 
-While our Open Data facet is conservative and only considers freely accessible data, other data marked as `requester pays <https://cloud.google.com/storage/docs/requester-pays>`_ may be trivial to access given payment".
+.. note::
+    Dockstore does not consider requester pays data such as `Google Cloud Requester Pays <https://cloud.google.com/storage/docs/requester-pays>`_  and `Amazon S3 Requester Pays <https://docs.aws.amazon.com/AmazonS3/latest/userguide/RequesterPaysBuckets.html>`_ to be open data.
+    Even though their data may be open, our Open Data facet only show those that are open and free.
 
 :ref:`(back to top) <topFAQ>`
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -80,7 +80,7 @@ When viewing an individual tool or workflow, you can tell which versions are Ope
 
 .. note::
     Dockstore does not consider requester pays data such as `Google Cloud Requester Pays <https://cloud.google.com/storage/docs/requester-pays>`_  and `Amazon S3 Requester Pays <https://docs.aws.amazon.com/AmazonS3/latest/userguide/RequesterPaysBuckets.html>`_ to be open data.
-    Even though their data may be open, our Open Data facet only show those that are open and free.
+    Even though their data may be open, our Open Data facet only shows those that are open and free.
 
 :ref:`(back to top) <topFAQ>`
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -78,6 +78,8 @@ Note that tool and workflow versions that do not require any file input paramete
 You can find Open Data workflows and tools by selecting the Open Data facet on the `search <https://dockstore.org/search>`_ page.
 When viewing an individual tool or workflow, you can tell which versions are Open Data on the Versions tab via the Open column.
 
+While our Open Data facet is conservative and only considers freely accessible data, other data marked as `requester pays <https://cloud.google.com/storage/docs/requester-pays>`_ may be trivial to access given payment".
+
 :ref:`(back to top) <topFAQ>`
 
 How should I register my work in Dockstore?


### PR DESCRIPTION
**Description**
This PR adds a line in the Open Data section of the FAQ that mentions that while our facet is open and free, accessing "non open data" may be requester's pay. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-3518

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If the PR has any new pages, only **AFTER** the PR is approved by all reviewers, generate a new discourse topic, by running the action at https://github.com/dockstore/dockstore-documentation/actions/workflows/add-discourse-topic.yml. Otherwise we may end up with orphaned topics, which would need manual management.
