### PR TITLE
SEAB-6149: Add workflow for weekly link check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,16 @@ workflows:
     jobs:
       - test
       - topic
+  weekly_link_check:
+    triggers:
+      - schedule:
+          cron: '30 12 * * 1' # Every Monday at 12:30pm UTC
+          filters:
+            branches:
+              only:
+                - develop
+    jobs:
+      - test
 commands:
   basic_test:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ workflows:
   weekly_link_check:
     triggers:
       - schedule:
-          cron: '30 12 * * 1' # Every Monday at 12:30pm UTC
+          cron: '30 12 * * 1' # Every Monday at 7:30am EST/4:30am PST
           filters:
             branches:
               only:


### PR DESCRIPTION
**Description**
Updates to the documentation repository tend to occur in clusters near release dates. As such, if a build fails due to a broken link, it can be unclear whether it was the most recent PR or an earlier event that produced the failed check.

Having a scheduled workflow that performs weekly checks should make it easier to trace the causes of link errors. It could also encourage us to monitor documentation links more regularly.

**Issue**
[SEAB-6149](https://ucsc-cgl.atlassian.net/browse/SEAB-6149?atlOrigin=eyJpIjoiMTM3MDk1MTJiZmZjNDZjY2JiOGIwZTZiNzRjNGEyZjgiLCJwIjoiaiJ9)

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If the PR has any new pages, only **AFTER** the PR is approved by all reviewers, generate a new discourse topic, by running the action at https://github.com/dockstore/dockstore-documentation/actions/workflows/add-discourse-topic.yml. Otherwise we may end up with orphaned topics, which would need manual management.


[SEAB-6149]: https://ucsc-cgl.atlassian.net/browse/SEAB-6149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ