### PR TITLE
SEAB-5979 & SEAB-6057: fixed sizing on long images

### DIFF
--- a/docs/getting-started/archive-on-dockstore.rst
+++ b/docs/getting-started/archive-on-dockstore.rst
@@ -40,7 +40,7 @@ You should now see your entry with the Archive button on the far right of the pa
 Read the dialog message and if you are sure you would like to archive, click the Archive This <Entry> button
 
 .. image:: /assets/images/docs/archive-workflow-dialog.png
-   :width: 50 %
+   :width: 75 %
 
 You will now see a banner that shows that your entry is archived and read-only.
 

--- a/docs/getting-started/archive-on-dockstore.rst
+++ b/docs/getting-started/archive-on-dockstore.rst
@@ -35,7 +35,7 @@ In the sidebar accordion, find the organization that your entry is in and click 
 You should now see your entry with the Archive button on the far right of the page. Click the Archive button.
 
 .. image:: /assets/images/docs/workflow-showing-archive-button.png
-   :width: 50 %
+   :width: 100 %
 
 Read the dialog message and if you are sure you would like to archive, click the Archive This <Entry> button
 
@@ -45,7 +45,7 @@ Read the dialog message and if you are sure you would like to archive, click the
 You will now see a banner that shows that your entry is archived and read-only.
 
 .. image:: /assets/images/docs/archived-workflow-banner.png
-   :width: 50 %
+   :width: 100 %
 
 Unarchiving an Entry
 ---------------------
@@ -59,12 +59,12 @@ In the sidebar accordion, find the organization that your entry is in and click 
 You should now see your entry with the Unarchive button on the far right of the page. Click the Unarchive button.
 
 .. image:: /assets/images/docs/archived-workflow-banner.png
-   :width: 50 %
+   :width: 100 %
 
 The archived banner should now be removed and your entry will function as normal.
 
 .. image:: /assets/images/docs/workflow-showing-archive-button.png
-   :width: 50 %
+   :width: 100 %
 
 
 .. discourse::

--- a/docs/getting-started/archive-on-dockstore.rst
+++ b/docs/getting-started/archive-on-dockstore.rst
@@ -40,7 +40,7 @@ You should now see your entry with the Archive button on the far right of the pa
 Read the dialog message and if you are sure you would like to archive, click the Archive This <Entry> button
 
 .. image:: /assets/images/docs/archive-workflow-dialog.png
-   :width: 75 %
+   :width: 50 %
 
 You will now see a banner that shows that your entry is archived and read-only.
 

--- a/docs/getting-started/delete-on-dockstore.rst
+++ b/docs/getting-started/delete-on-dockstore.rst
@@ -34,7 +34,7 @@ In the sidebar accordion, find the GitHub repository that your entry is in and c
 You should now see your entry with the Delete button on the far right of the page. Click the Delete button.
 
 .. image:: /assets/images/docs/workflow-showing-delete-button.png
-   :width: 50 %
+   :width: 100 %
 
 Read the dialog message and if you are sure you would like to delete, click the Delete this workflow/tool/notebook/service button
 

--- a/docs/getting-started/delete-on-dockstore.rst
+++ b/docs/getting-started/delete-on-dockstore.rst
@@ -44,3 +44,5 @@ Read the dialog message and if you are sure you would like to delete, click the 
 Please make sure that you have uninstalled the Dockstore GitHub App from the source GitHub repo, or edited/removed the ``.dockstore.yml`` file so that it no longer describes the deleted entry.
 If you do not, your deleted entry may reappear on Dockstore the next time you push to the repo.
 
+.. discourse::
+    :topic_identifier: 8025

--- a/docs/getting-started/delete-on-dockstore.rst
+++ b/docs/getting-started/delete-on-dockstore.rst
@@ -39,7 +39,7 @@ You should now see your entry with the Delete button on the far right of the pag
 Read the dialog message and if you are sure you would like to delete, click the Delete this workflow/tool/notebook/service button
 
 .. image:: /assets/images/docs/delete-workflow-dialog.png
-   :width: 75 %
+   :width: 50 %
 
 Please make sure that you have uninstalled the Dockstore GitHub App from the source GitHub repo, or edited/removed the ``.dockstore.yml`` file so that it no longer describes the deleted entry.
 If you do not, your deleted entry may reappear on Dockstore the next time you push to the repo.

--- a/docs/getting-started/delete-on-dockstore.rst
+++ b/docs/getting-started/delete-on-dockstore.rst
@@ -39,7 +39,7 @@ You should now see your entry with the Delete button on the far right of the pag
 Read the dialog message and if you are sure you would like to delete, click the Delete this workflow/tool/notebook/service button
 
 .. image:: /assets/images/docs/delete-workflow-dialog.png
-   :width: 50 %
+   :width: 75 %
 
 Please make sure that you have uninstalled the Dockstore GitHub App from the source GitHub repo, or edited/removed the ``.dockstore.yml`` file so that it no longer describes the deleted entry.
 If you do not, your deleted entry may reappear on Dockstore the next time you push to the repo.


### PR DESCRIPTION
**Description**
I just checked the documentation page for the Delete entry and Archive entry features I created and some images seem to be too small. This PR fixes that.

Before fix:

Delete entry page
![Screenshot from 2024-02-09 09-31-02](https://github.com/dockstore/dockstore-documentation/assets/61166764/53ab48da-861d-498d-937e-475921999e3d)

Archive entry page
![Screenshot from 2024-02-09 09-30-42](https://github.com/dockstore/dockstore-documentation/assets/61166764/97716aa6-8c93-4cae-b215-caa56ce43450)


After fix:

Delete entry page:
![Screenshot from 2024-02-09 09-44-02](https://github.com/dockstore/dockstore-documentation/assets/61166764/00096e3a-55f7-48c4-b175-60a1204dc93d)


Archive entry page:
![Screenshot from 2024-02-09 09-43-26](https://github.com/dockstore/dockstore-documentation/assets/61166764/d662e133-42e4-41f6-91b9-4cb66bd6a204)


**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6057
https://ucsc-cgl.atlassian.net/browse/SEAB-5979

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If the PR has any new pages, only **AFTER** the PR is approved by all reviewers, generate a new discourse topic, by running the action at https://github.com/dockstore/dockstore-documentation/actions/workflows/add-discourse-topic.yml. Otherwise we may end up with orphaned topics, which would need manual management.
