### PR TITLE
Bump some requirements as suggested by dependabot PRs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,10 @@ certifi==2023.11.17
 charset-normalizer==3.3.2
 docutils==0.17.1
 glossarpy==0.1.2
-idna==3.6
+idna==3.7
 imagesize==1.4.1
 importlib-metadata==7.0.1
-Jinja2==3.1.3
+Jinja2==3.1.4
 markdown-it-py==2.2.0
 MarkupSafe==2.1.3
 mdit-py-plugins==0.3.5
@@ -17,7 +17,7 @@ myst-parser==0.16.1
 packaging==23.2
 Pygments==2.17.2
 PyYAML==6.0.1
-requests==2.31.0
+requests==2.32.3
 snowballstemmer==2.2.0
 Sphinx==4.4.0
 sphinx-rtd-theme==1.0.0
@@ -28,5 +28,5 @@ sphinxcontrib-htmlhelp==2.0.1
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.3
 sphinxcontrib-serializinghtml==1.1.5
-urllib3==2.1.0
+urllib3==2.2.2
 zipp==3.17.0


### PR DESCRIPTION
**Description**
This PR changes the version of some required Python packages as suggested by the following group of dependabot PRs:
https://github.com/dockstore/dockstore-documentation/pull/277
https://github.com/dockstore/dockstore-documentation/pull/279
https://github.com/dockstore/dockstore-documentation/pull/276
https://github.com/dockstore/dockstore-documentation/pull/278

Version 2.32.0 of `requests` was yanked due to some CVEs, so it was updated to the latest.

**Issue**
none

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If the PR has any new pages, only **AFTER** the PR is approved by all reviewers, generate a new discourse topic, by running the action at https://github.com/dockstore/dockstore-documentation/actions/workflows/add-discourse-topic.yml. Otherwise we may end up with orphaned topics, which would need manual management.
