### PR TITLE
Add missing break

### DIFF
--- a/docs/_static/language-support.html
+++ b/docs/_static/language-support.html
@@ -93,6 +93,7 @@
             </td>
             <td style="background-color:#dff0d8; padding: 5px;">
                 <a href="../launch-with/galaxy-launch-with.html">Galaxy</a>
+                <br>
                 <a href="../getting-started/getting-started-with-galaxy.html#custom-galaxy-in-the-cloud-with-terra-anvil-and-biodata-catalyst">Galaxy (in Terra)</a>
             </td>
         </tr>


### PR DESCRIPTION
**Description**
Noticed when reviewing another ticket, language support table says "Galaxy Galaxy..."

Before:

<img width="259" alt="Screen Shot 2024-07-30 at 9 38 30 AM" src="https://github.com/user-attachments/assets/7ad17d42-cf48-4b1a-b262-925580c5544f">

After:

<img width="285" alt="Screen Shot 2024-07-30 at 9 38 24 AM" src="https://github.com/user-attachments/assets/544a2043-709a-46bf-a711-facabbb399d9">

**Issue**
Didn't create one.

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If the PR has any new pages, only **AFTER** the PR is approved by all reviewers, generate a new discourse topic, by running the action at https://github.com/dockstore/dockstore-documentation/actions/workflows/add-discourse-topic.yml. Otherwise we may end up with orphaned topics, which would need manual management.
