### PR TITLE
Add baseurl from environment (hotfix)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -153,6 +153,10 @@ html_logo = 'assets/images/Dockstore-Documentation-horizontal-white.png'
 # Set canonical URL from the Read the Docs Domain
 html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
 
+html_context = {}
+
+html_context["READTHEDOCS"] = False
+
 # Tell Jinja2 templates the build is running on Read the Docs
 if os.environ.get("READTHEDOCS", "") == "True":
     html_context["READTHEDOCS"] = True

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,6 +20,8 @@
 # -- Project information -----------------------------------------------------
 
 import datetime
+import os
+
 
 project = u'Dockstore'
 copyright = f'2021-{datetime.date.today().year}, OICR, and UCSC'
@@ -147,6 +149,13 @@ html_static_path = ['_static']
 #
 # html_sidebars = {}
 html_logo = 'assets/images/Dockstore-Documentation-horizontal-white.png'
+
+# Set canonical URL from the Read the Docs Domain
+html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "")
+
+# Tell Jinja2 templates the build is running on Read the Docs
+if os.environ.get("READTHEDOCS", "") == "True":
+    html_context["READTHEDOCS"] = True
 
 
 # -- Options for HTMLHelp output ---------------------------------------------


### PR DESCRIPTION
**Description**

RTD is deprecating an existing method of injecting the basename into your docs for if you use a custom domain. They suggest this change to make your docs work with the new method.

https://about.readthedocs.com/blog/2024/07/addons-by-default/

This PR is for the hotfix, there is another for develop https://github.com/dockstore/dockstore-documentation/pull/289

https://readthedocs.org/projects/dockstore/builds/25326501/

https://dockstore--290.org.readthedocs.build/en/290/

**Issue**

https://ucsc-cgl.atlassian.net/browse/SEAB-6573

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [ ] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [ ] If the PR has any new pages, only **AFTER** the PR is approved by all reviewers, generate a new discourse topic, by running the action at https://github.com/dockstore/dockstore-documentation/actions/workflows/add-discourse-topic.yml. Otherwise we may end up with orphaned topics, which would need manual management.
