### PR TITLE
SEAB-6738: Tweak Automatic DOI Section

### DIFF
--- a/docs/end-user-topics/dois.rst
+++ b/docs/end-user-topics/dois.rst
@@ -69,10 +69,15 @@ Automatic Dockstore DOI Generation
 .. note::
     This feature is currently only available on request. Please contact the Dockstore team at `discuss.dockstore.org <https://discuss.dockstore.org/t/opening-helpdesk-tickets/1506>`__ if you want to participate.
 
-* Automatically mints DOIs for all Git tags pushed to GitHub repositories that have a corresponding published entry in Dockstore
-* The DOIs are minted in the Zenodo Dockstore community
-* No Zenodo account is required to mint DOIs
-* A linked Zenodo account is required to edit DOIs
+Dockstore will automatically mint a DOI for a version that corresponds to a Git tag, if:
+
+* The entry is published on Dockstore
+* The version has at least one author in its metadata
+* The tag was created after the entry was published, or the tag is one of the 10 most recent
+
+* Automatic DOIs are minted in the Zenodo Dockstore community
+* No Zenodo account is required to mint automatic DOIs
+* In a subsequent release, automatic DOIs will be editable via a linked Zenodo account
 
 GitHub-Zenodo Generation
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/end-user-topics/dois.rst
+++ b/docs/end-user-topics/dois.rst
@@ -72,7 +72,7 @@ Automatic Dockstore DOI Generation
 Dockstore will automatically mint a DOI for a version that corresponds to a Git tag, if:
 
 * The entry is published on Dockstore
-* The version has at least one author in its metadata
+* The version is valid and has at least one author in its metadata
 * The tag is created after you publish the entry, or the tag is one of the 10 most recent when you publish the entry
 
 Automatically-generated DOIs:

--- a/docs/end-user-topics/dois.rst
+++ b/docs/end-user-topics/dois.rst
@@ -73,14 +73,14 @@ Dockstore will automatically mint a DOI for a version that corresponds to a Git 
 
 * The entry is published on Dockstore
 * The version has at least one author in its metadata
-* The tag was created after the entry was published, or the tag is one of the 10 most recent
+* The tag is created after you publish the entry, or the tag is one of the 10 most recent when you publish the entry
 
 Automatically-generated DOIs:
 
 * Do not require a Zenodo account
 * Are minted in the Zenodo Dockstore community
 * Are editable by request to the Dockstore team
-* Will be editable via a linked Zenodo account in a subsequent Dockstore release
+* Will be editable via a Zenodo account in a subsequent Dockstore release
 
 GitHub-Zenodo Generation
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/end-user-topics/dois.rst
+++ b/docs/end-user-topics/dois.rst
@@ -75,9 +75,11 @@ Dockstore will automatically mint a DOI for a version that corresponds to a Git 
 * The version has at least one author in its metadata
 * The tag was created after the entry was published, or the tag is one of the 10 most recent
 
-* Automatic DOIs are minted in the Zenodo Dockstore community
-* No Zenodo account is required to mint automatic DOIs
-* In a subsequent release, automatic DOIs will be editable via a linked Zenodo account
+Automatically-generated DOIs:
+
+* Do not require a Zenodo account
+* Are minted in the Zenodo Dockstore community
+* Will be editable via a linked Zenodo account in a subsequent Dockstore release
 
 GitHub-Zenodo Generation
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/end-user-topics/dois.rst
+++ b/docs/end-user-topics/dois.rst
@@ -79,6 +79,7 @@ Automatically-generated DOIs:
 
 * Do not require a Zenodo account
 * Are minted in the Zenodo Dockstore community
+* Are editable by request to the Dockstore team
 * Will be editable via a linked Zenodo account in a subsequent Dockstore release
 
 GitHub-Zenodo Generation


### PR DESCRIPTION
**Description**
This PR enhances the new "Automatic Dockstore DOI Generation" section.  It is an attempt to codify the bits of information present in this Slack thread: https://ucsc-gi.slack.com/archives/C05EZH3RVNY/p1730923309122769

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6738

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If the PR has any new pages, only **AFTER** the PR is approved by all reviewers, generate a new discourse topic, by running the action at https://github.com/dockstore/dockstore-documentation/actions/workflows/add-discourse-topic.yml. Otherwise we may end up with orphaned topics, which would need manual management.
