### PR TITLE
document auto dois opt-out setting

### DIFF
--- a/docs/assets/templates/notebooks/template-big.dockstore.yml
+++ b/docs/assets/templates/notebooks/template-big.dockstore.yml
@@ -65,7 +65,7 @@ notebooks:
     latestTagAsDefault: <Boolean>
 
     # 'enableAutoDois' is a notebook-wide setting that will affect ALL branches/tags; only set this as needed in a main branch
-    # to control whether DOIs are automatically issued for tags. Implicit default: True.
+    # to control whether DOIs are automatically issued for tags. Implicit default: True, can only be overridden as False
     # A value of false will disable automatic DOIs, DOIs will only be issued on demand.
     enableAutoDois: <Boolean>
     

--- a/docs/assets/templates/notebooks/template-big.dockstore.yml
+++ b/docs/assets/templates/notebooks/template-big.dockstore.yml
@@ -63,6 +63,11 @@ notebooks:
     # A value of true will automatically display the latest tag updated as default.
     # A value of false will retain the default version that has been specified via the Dockstore UI.
     latestTagAsDefault: <Boolean>
+
+    # A boolean that will control whether DOIs are automatically issued for tags. Default: True.
+    # A value of true will allow Dockstore to automatically issue DOIs.
+    # A value of false will disable automatic DOIs, DOIs will only be issued on demand.
+    enableAutoDois: <Boolean>
     
     # The optional filters section allow specifying sets of Git branches and tags to include for the notebook.
     # If no filters are given, all branches and tags are included.

--- a/docs/assets/templates/notebooks/template-big.dockstore.yml
+++ b/docs/assets/templates/notebooks/template-big.dockstore.yml
@@ -64,8 +64,8 @@ notebooks:
     # A value of false will retain the default version that has been specified via the Dockstore UI.
     latestTagAsDefault: <Boolean>
 
-    # A boolean that will control whether DOIs are automatically issued for tags. Default: True.
-    # A value of true will allow Dockstore to automatically issue DOIs.
+    # 'enableAutoDois' is a notebook-wide setting that will affect ALL branches/tags; only set this as needed in a main branch
+    # to control whether DOIs are automatically issued for tags. Implicit default: True.
     # A value of false will disable automatic DOIs, DOIs will only be issued on demand.
     enableAutoDois: <Boolean>
     

--- a/docs/assets/templates/notebooks/template-small.dockstore.yml
+++ b/docs/assets/templates/notebooks/template-small.dockstore.yml
@@ -15,4 +15,3 @@ notebooks:
       - name: <String>
         email: <String>
     topic: <String>
-    enableAutoDois: <Boolean>

--- a/docs/assets/templates/notebooks/template-small.dockstore.yml
+++ b/docs/assets/templates/notebooks/template-small.dockstore.yml
@@ -15,3 +15,4 @@ notebooks:
       - name: <String>
         email: <String>
     topic: <String>
+    enableAutoDois: <Boolean>

--- a/docs/assets/templates/services/template-big.dockstore.yml
+++ b/docs/assets/templates/services/template-big.dockstore.yml
@@ -34,8 +34,8 @@ service:
   publish:
 
   # 'enableAutoDois' is a service-wide setting that will affect ALL branches/tags; only set this as needed in a main branch
-  # to control whether DOIs are automatically issued for tags. Implicit default: True.
-  #    # A value of false will disable automatic DOIs, DOIs will only be issued on demand.
+  # to control whether DOIs are automatically issued for tags. Implicit default: True, can only be overridden as False
+  # A value of false will disable automatic DOIs, DOIs will only be issued on demand.
   enableAutoDois: <Boolean>
 
   # These are files the Dockstore will index. They will be directly downloadable from Dockstore. Wildcards are not supported.

--- a/docs/assets/templates/services/template-big.dockstore.yml
+++ b/docs/assets/templates/services/template-big.dockstore.yml
@@ -33,6 +33,11 @@ service:
   # Omitting the publish setting leaves the publish-state unchanged (recommended for all non-primary branches).
   publish:
 
+  # A boolean that will control whether DOIs are automatically issued for tags. Default: True.
+  # A value of true will allow Dockstore to automatically issue DOIs.
+  # A value of false will disable automatic DOIs, DOIs will only be issued on demand.
+  enableAutoDois: <Boolean>
+
   # These are files the Dockstore will index. They will be directly downloadable from Dockstore. Wildcards are not supported.
   files:
 

--- a/docs/assets/templates/services/template-big.dockstore.yml
+++ b/docs/assets/templates/services/template-big.dockstore.yml
@@ -33,9 +33,9 @@ service:
   # Omitting the publish setting leaves the publish-state unchanged (recommended for all non-primary branches).
   publish:
 
-  # A boolean that will control whether DOIs are automatically issued for tags. Default: True.
-  # A value of true will allow Dockstore to automatically issue DOIs.
-  # A value of false will disable automatic DOIs, DOIs will only be issued on demand.
+  # 'enableAutoDois' is a service-wide setting that will affect ALL branches/tags; only set this as needed in a main branch
+  # to control whether DOIs are automatically issued for tags. Implicit default: True.
+  #    # A value of false will disable automatic DOIs, DOIs will only be issued on demand.
   enableAutoDois: <Boolean>
 
   # These are files the Dockstore will index. They will be directly downloadable from Dockstore. Wildcards are not supported.

--- a/docs/assets/templates/services/template-small.dockstore.yml
+++ b/docs/assets/templates/services/template-small.dockstore.yml
@@ -21,4 +21,3 @@ service:
       files:
         <String-name-of-file>:
           description: <String>
-  enableAutoDois: <Boolean>

--- a/docs/assets/templates/services/template-small.dockstore.yml
+++ b/docs/assets/templates/services/template-small.dockstore.yml
@@ -21,3 +21,4 @@ service:
       files:
         <String-name-of-file>:
           description: <String>
+  enableAutoDois: <Boolean>

--- a/docs/assets/templates/workflows/template-big.dockstore.yml
+++ b/docs/assets/templates/workflows/template-big.dockstore.yml
@@ -65,6 +65,11 @@ workflows:
     # A value of true will automatically display the latest tag updated as default.
     # A value of false will retain the default version that has been specified via the Dockstore UI.
     latestTagAsDefault: <Boolean>
+
+    # A boolean that will control whether DOIs are automatically issued for tags. Default: True.
+    # A value of true will allow Dockstore to automatically issue DOIs.
+    # A value of false will disable automatic DOIs, DOIs will only be issued on demand.
+    enableAutoDois: <Boolean>
     
     # The optional filters section allow specifying sets of Git branches and tags to include for the workflow.
     # If no filters are given, all branches and tags are included.

--- a/docs/assets/templates/workflows/template-big.dockstore.yml
+++ b/docs/assets/templates/workflows/template-big.dockstore.yml
@@ -67,8 +67,8 @@ workflows:
     latestTagAsDefault: <Boolean>
 
     # 'enableAutoDois' is a workflow-wide setting that will affect ALL branches/tags; only set this as needed in a main branch
-    # to control whether DOIs are automatically issued for tags. Implicit default: True.
-    #    # A value of false will disable automatic DOIs, DOIs will only be issued on demand.
+    # to control whether DOIs are automatically issued for tags. Implicit default: True, can only be overridden as False
+    # A value of false will disable automatic DOIs, DOIs will only be issued on demand.
     enableAutoDois: <Boolean>
     
     # The optional filters section allow specifying sets of Git branches and tags to include for the workflow.

--- a/docs/assets/templates/workflows/template-big.dockstore.yml
+++ b/docs/assets/templates/workflows/template-big.dockstore.yml
@@ -66,9 +66,9 @@ workflows:
     # A value of false will retain the default version that has been specified via the Dockstore UI.
     latestTagAsDefault: <Boolean>
 
-    # A boolean that will control whether DOIs are automatically issued for tags. Default: True.
-    # A value of true will allow Dockstore to automatically issue DOIs.
-    # A value of false will disable automatic DOIs, DOIs will only be issued on demand.
+    # 'enableAutoDois' is a workflow-wide setting that will affect ALL branches/tags; only set this as needed in a main branch
+    # to control whether DOIs are automatically issued for tags. Implicit default: True.
+    #    # A value of false will disable automatic DOIs, DOIs will only be issued on demand.
     enableAutoDois: <Boolean>
     
     # The optional filters section allow specifying sets of Git branches and tags to include for the workflow.

--- a/docs/assets/templates/workflows/template-small.dockstore.yml
+++ b/docs/assets/templates/workflows/template-small.dockstore.yml
@@ -10,3 +10,4 @@ workflows:
       - name: <String>
         email: <String>
     topic: <String>
+    enableAutoDois: <Boolean>

--- a/docs/assets/templates/workflows/template-small.dockstore.yml
+++ b/docs/assets/templates/workflows/template-small.dockstore.yml
@@ -10,4 +10,3 @@ workflows:
       - name: <String>
         email: <String>
     topic: <String>
-    enableAutoDois: <Boolean>

--- a/docs/end-user-topics/dois.rst
+++ b/docs/end-user-topics/dois.rst
@@ -92,7 +92,7 @@ If you wish to override and disable this feature, you can opt-out on a per-workf
 One rare case to potentially watch out for: if your workflows are tagged with your ORCID as an author
 you may get a large number of notifications or workflows automatically added to your ORCID profile.
 This will occur outside of Dockstore if you have the `ORCID Auto-Update <https://support.datacite.org/docs/datacite-and-orcid#2-orcid-auto-update>`__ feature turned on in DataCite.
-DataCite's auto-update feature is not aware of Zenodo's concept DOI concept and will import each version independently.
+DataCite's auto-update feature is not aware of how Zenodo groups DOIs into one overall "concept" DOI and will import each version independently.
 
 GitHub-Zenodo Generation
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/end-user-topics/dois.rst
+++ b/docs/end-user-topics/dois.rst
@@ -84,9 +84,8 @@ Automatically-generated DOIs:
 
 If you wish to override and disable this feature, you can opt-out on a per-workflow basis you can add the following setting to your `.dockstore.yml` files
 
-```
+.. code-block:: yaml
    enableAutoDois: false
-```
 
 GitHub-Zenodo Generation
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/end-user-topics/dois.rst
+++ b/docs/end-user-topics/dois.rst
@@ -88,6 +88,12 @@ If you wish to override and disable this feature, you can opt-out on a per-workf
 
    enableAutoDois: false
 
+
+One rare case to potentially watch out for: if your workflows are tagged with your ORCID as an author
+you may get a large number of notifications or workflows automatically added to your ORCID profile.
+This will occur outside of Dockstore if you have the `ORCID Auto-Update <https://support.datacite.org/docs/datacite-and-orcid#2-orcid-auto-update>`__ feature turned on in DataCite.
+DataCite's auto-update feature is not aware of Zenodo's concept DOI concept and will import each version independently.
+
 GitHub-Zenodo Generation
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/end-user-topics/dois.rst
+++ b/docs/end-user-topics/dois.rst
@@ -82,7 +82,7 @@ Automatically-generated DOIs:
 * Are editable by request to the Dockstore team
 * Will be editable via a Zenodo account in a subsequent Dockstore release
 
-If you wish to override and disable this feature, you can opt-out on a per-workflow basis you can add the following setting to your `.dockstore.yml` files
+If you wish to override and disable this feature, you can opt-out on a per-workflow basis by adding the following setting to your `.dockstore.yml` files
 
 .. code-block:: yaml
 

--- a/docs/end-user-topics/dois.rst
+++ b/docs/end-user-topics/dois.rst
@@ -85,6 +85,7 @@ Automatically-generated DOIs:
 If you wish to override and disable this feature, you can opt-out on a per-workflow basis you can add the following setting to your `.dockstore.yml` files
 
 .. code-block:: yaml
+
    enableAutoDois: false
 
 GitHub-Zenodo Generation

--- a/docs/end-user-topics/dois.rst
+++ b/docs/end-user-topics/dois.rst
@@ -82,6 +82,12 @@ Automatically-generated DOIs:
 * Are editable by request to the Dockstore team
 * Will be editable via a Zenodo account in a subsequent Dockstore release
 
+If you wish to override and disable this feature, you can opt-out on a per-workflow basis you can add the following setting to your `.dockstore.yml` files
+
+```
+   enableAutoDois: false
+```
+
 GitHub-Zenodo Generation
 ~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
**Description**
Document DOI opt-out option in templates and in the DOI article. 

View draft at https://docs.dockstore.org/en/feature-document_enable_auto_doi/

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6833

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If the PR has any new pages, only **AFTER** the PR is approved by all reviewers, generate a new discourse topic, by running the action at https://github.com/dockstore/dockstore-documentation/actions/workflows/add-discourse-topic.yml. Otherwise we may end up with orphaned topics, which would need manual management.
