### PR TITLE
docker schema update

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,22 @@
+name: Docker Image CI
+
+on: [push]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    # Check on tutorial docker containers 
+    - run: docker pull quay.io/briandoconnor/dockstore-tool-md5sum
+    - run: docker pull docker/whalesay
+    - run: docker pull quay.io/ldcabansay/samtools
+    - run: docker pull tabix:latest
+    - run: docker pull quay.io/collaboratory/dockstore-tool-bamstats:1.25-6
+    - run: docker pull pkrusche/hap.py:v1.0
+    - run: docker pull pkrusche/hap.py:latest
+    - run: docker pull biocontainers/samtools:v1.9-4-deb_cv1
+    - run: docker pull pkrusche/hap.py:latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,4 +21,3 @@ jobs:
     # - run: docker pull pkrusche/hap.py:v1.0
     # - run: docker pull pkrusche/hap.py:latest
     - run: docker pull biocontainers/samtools:v1.9-4-deb_cv1
-    - run: docker pull pkrusche/hap.py:latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
-    # Check on tutorial docker containers 
+    # Check on tutorial docker containers
     - run: docker pull quay.io/dockstore-testing/dockstore-tool-md5sum
     - run: docker pull rancher/cowsay
     - run: docker pull quay.io/ldcabansay/samtools
-    # this container is built by the user, not pulled from docker hub
+    # in a text search, this container looks legitmate, but this container is built by the user, not pulled from docker hub
+    # leaving it to avoid the next developer adding it again
     # - run: docker pull tabix:latest
     - run: docker pull quay.io/collaboratory/dockstore-tool-bamstats:1.25-6
     # these seem to be fake examples

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     # Check on tutorial docker containers 
-    - run: docker pull quay.io/briandoconnor/dockstore-tool-md5sum
+    - run: docker pull quay.io/dockstore-testing/dockstore-tool-md5sum
     - run: docker pull docker/whalesay
     - run: docker pull quay.io/ldcabansay/samtools
     - run: docker pull tabix:latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@v4
     # Check on tutorial docker containers 
     - run: docker pull quay.io/dockstore-testing/dockstore-tool-md5sum
-    - run: docker pull docker/whalesay
+    - run: docker pull rancher/cowsay
     - run: docker pull quay.io/ldcabansay/samtools
     - run: docker pull tabix:latest
     - run: docker pull quay.io/collaboratory/dockstore-tool-bamstats:1.25-6

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,7 +17,8 @@ jobs:
     # this container is built by the user, not pulled from docker hub
     # - run: docker pull tabix:latest
     - run: docker pull quay.io/collaboratory/dockstore-tool-bamstats:1.25-6
-    - run: docker pull pkrusche/hap.py:v1.0
-    - run: docker pull pkrusche/hap.py:latest
+    # these seem to be fake examples
+    # - run: docker pull pkrusche/hap.py:v1.0
+    # - run: docker pull pkrusche/hap.py:latest
     - run: docker pull biocontainers/samtools:v1.9-4-deb_cv1
     - run: docker pull pkrusche/hap.py:latest

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -14,7 +14,8 @@ jobs:
     - run: docker pull quay.io/dockstore-testing/dockstore-tool-md5sum
     - run: docker pull rancher/cowsay
     - run: docker pull quay.io/ldcabansay/samtools
-    - run: docker pull tabix:latest
+    # this container is built by the user, not pulled from docker hub
+    # - run: docker pull tabix:latest
     - run: docker pull quay.io/collaboratory/dockstore-tool-bamstats:1.25-6
     - run: docker pull pkrusche/hap.py:v1.0
     - run: docker pull pkrusche/hap.py:latest

--- a/docs/advanced-topics/aws-batch.rst
+++ b/docs/advanced-topics/aws-batch.rst
@@ -86,7 +86,7 @@ the box.
    and the parameters that it will take.
 
    1. For a quick test, you can try the command
-      ``/test.sh quay.io/briandoconnor/dockstore-tool-md5sum:1.0.3 https://raw.githubusercontent.com/dockstore/batch_wrapper/master/aws/md5sum.s3.json``
+      ``/test.sh quay.io/dockstore-testing/dockstore-tool-md5sum https://raw.githubusercontent.com/dockstore/batch_wrapper/master/aws/md5sum.s3.json``
       after modifying md5sum.s3.json to point to your S3 bucket rather
       than dockstore.temp and uploading it somewhere accessible. This
       will run a quick md5sum tool that copies the result to a S3 bucket

--- a/docs/advanced-topics/checksum-support.rst
+++ b/docs/advanced-topics/checksum-support.rst
@@ -77,7 +77,7 @@ Docker CLI client.
 
 ::
 
-    docker pull quay.io/briandoconnor/dockstore-tool-md5sum:1.0.4
+    docker pull quay.io/dockstore-testing/dockstore-tool-md5sum
 
 When the download has completed, a digest is provided in the terminal output. This should match the checksum provided
 by the Dockstore API.

--- a/docs/advanced-topics/dockstore-cli/developing-file-provisioning-plugins.rst
+++ b/docs/advanced-topics/dockstore-cli/developing-file-provisioning-plugins.rst
@@ -43,7 +43,7 @@ The steps for implementing a new plugin are as follows:
 8. Build the plugin with ``mvn clean install`` and copy the result zip
    file to the plugin directory.
 9. Test with a simple tool such as
-   `md5sum <https://github.com/briandoconnor/dockstore-tool-md5sum>`__.
+   `md5sum <https://github.com/dockstore-testing/dockstore-tool-md5sum>`__.
 
 You should see something similar to the following
 
@@ -62,7 +62,7 @@ You should see something similar to the following
         }
     }
 
-    $ dockstore tool launch --entry  quay.io/briandoconnor/dockstore-tool-md5sum  --json test.s3.json
+    $ dockstore tool launch --entry  quay.io/dockstore-testing/dockstore-tool-md5sum  --json test.s3.json
     Creating directories for run of Dockstore launcher at: ./datastore//launcher-a246f1b6-21fd-468e-8780-b064d311dda5
     Provisioning your input files to your local machine
     Downloading: #input_file from s3://oicr.temp/bamstats_report.zip into directory: /media/large_volume/dockstore_tools/dockstore-tool-md5sum/./datastore/launcher-a246f1b6-21fd-468e-8780-b064d311dda5/inputs/73b70f11

--- a/docs/docker_instructions.md
+++ b/docs/docker_instructions.md
@@ -10,27 +10,20 @@ In this section you will try running a basic container called whalesay. Refer to
 
 Run whalesay with the following command:
 ```shell
-docker run docker/whalesay cowsay hello
+docker run rancher/cowsay cowsay hello
 ```
 
 This will result in an ASCII whale saying hello!
 ```shell
-docker run docker/whalesay cowsay "hello"
- _______ 
-< hello >
- ------- 
-    \
-     \
-      \     
-                    ##        .            
-              ## ## ##       ==            
-           ## ## ## ##      ===            
-       /""""""""""""""""___/ ===        
-  ~~~ {~~ ~~~~ ~~~ ~~~~ ~~ ~ /  ===- ~~~   
-       \______ o          __/            
-        \    \        __/             
-          \____\______/   
-
+docker run rancher/cowsay cowsay hello
+  ______________ 
+< cowsay hello >
+ -------------- 
+        \   ^__^
+         \  (oo)\_______
+            (__)\       )\/\
+                ||----w |
+                ||     ||
 ```
 
 Now try getting the whale to say "Hello [your name]!".
@@ -115,7 +108,7 @@ There are readings to help with the exercises. Refer here for any questions you 
 
 ### Exercise 1
 #### Part A Readings
-Whalesay is a program that given some text, will print out an ASCII whale that is saying the text. It is based on a program called cowsay.
+Cowsay is a program that given some text, will print out an ASCII cow that is saying the text. It is based on a program called cowsay.
 
 The docker run command is used to create a running container based on a Docker image. You can read more about the run command from their [official documentation](https://docs.docker.com/reference/cli/docker/container/run/).
 

--- a/docs/docker_instructions.md
+++ b/docs/docker_instructions.md
@@ -6,14 +6,14 @@ The Docker CLI is a command-line tool with a whole library of commands for inter
 
 
 ### Part A - Running Containers
-In this section you will try running a basic container called whalesay. Refer to the [part A readings](#part-a-readings) if you need a refresher on the content taught in the training.
+In this section you will try running a basic container called cowsay. Refer to the [part A readings](#part-a-readings) if you need a refresher on the content taught in the training.
 
-Run whalesay with the following command:
+Run cowsay with the following command:
 ```shell
 docker run rancher/cowsay cowsay hello
 ```
 
-This will result in an ASCII whale saying hello!
+This will result in an ASCII cow saying hello!
 ```shell
 docker run rancher/cowsay cowsay hello
   ______________ 
@@ -26,7 +26,7 @@ docker run rancher/cowsay cowsay hello
                 ||     ||
 ```
 
-Now try getting the whale to say "Hello [your name]!".
+Now try getting the cow to say "Hello [your name]!".
 
 ### Part B - Exploring Containers
 We will now try running a container with [Samtools](https://www.htslib.org/) installed to convert a SAM file to a BAM file. Refer to the [part B readings](#part-b-readings) if you need a refresher on the content taught in the training.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -290,7 +290,7 @@ Advanced developer topics
 .. |CollabLink| image:: /assets/images/affiliations/collaboratory.png
     :alt: collaboratory
     :height: 55px
-.. _CollabLink: https://cancercollaboratory.org
+.. _CollabLink: https://doi.org/10.1158/1538-7445.AM2017-378
 
 .. |OicrLink| image:: /assets/images/affiliations/oicr.png
     :alt: oicr


### PR DESCRIPTION
**Description**
Follow-up for Docker schema deprecation issue https://docs.docker.com/engine/deprecated/#pushing-and-pulling-with-image-manifest-v2-schema-1  We've switched integration tests before but not the tutorials. 
Test that Docker images used in tutorials are monitored by github in case of future deprecation
Updated container that we control, switched when we cannot. 

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-6852

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If the PR has any new pages, only **AFTER** the PR is approved by all reviewers, generate a new discourse topic, by running the action at https://github.com/dockstore/dockstore-documentation/actions/workflows/add-discourse-topic.yml. Otherwise we may end up with orphaned topics, which would need manual management.
