### PR TITLE
SEAB-7016: Add SMK to example .dockstore.yml

### DIFF
--- a/docs/assets/templates/workflows/template-big.dockstore.yml
+++ b/docs/assets/templates/workflows/template-big.dockstore.yml
@@ -14,9 +14,9 @@ workflows:
   # up, the order of fields within a .dockstore.yml is not important.
   - name: <String>
     
-    # The descriptor language used for the workflow. CWL, WDL, NFL (Nextflow), or GALAXY. 
+    # The descriptor language used for the workflow. CWL, WDL, NFL (Nextflow), GALAXY, or SMK (Snakemake).
     # This cannot be changed once the workflow is registered.
-    subclass: <CWL | WDL | NFL | GALAXY>
+    subclass: <CWL | WDL | NFL | GALAXY | SMK>
     
     # Workflow-wide setting that will affect ALL branches/tags; only set this as needed in a main branch.
     # Set to true to publish an unpublished workflow, or false to unpublish a published workflow.

--- a/docs/assets/templates/workflows/template-small.dockstore.yml
+++ b/docs/assets/templates/workflows/template-small.dockstore.yml
@@ -1,6 +1,6 @@
 version: 1.2
 workflows:
-  - subclass: <CWL | WDL | NFL | GALAXY>
+  - subclass: <CWL | WDL | NFL | GALAXY | SMK>
     primaryDescriptorPath: <String>
     testParameterFiles:
       - <String>

--- a/docs/assets/templates/workflows/workflows.rst
+++ b/docs/assets/templates/workflows/workflows.rst
@@ -47,5 +47,5 @@ See Also
 --------
 
 * :doc:`.dockstore.yml templates for registering services </assets/templates/services/services>`
-* :doc:`.dockstore.yml templates for registering workflows </assets/templates/workflows/workflows>`
+* :doc:`.dockstore.yml templates for registering notebooks </assets/templates/notebooks/notebooks>`
 * :doc:`Other documentation regarding the GitHub App </getting-started/github-apps/github-apps-landing-page>`

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,7 +83,9 @@ linkcheck_ignore = [
     'https://aws.github.io/amazon-genomics-cli/docs/concepts/data/',
     'https://aws.github.io/amazon-genomics-cli',
     # sphinx reports
-    'https://www.go-fair.org/fair-principles/'
+    'https://www.go-fair.org/fair-principles/',
+    # sometimes hangs on the cloudflare check
+    'https://bioportal.bioontology.org/ontologies/EDAM'
     ]
 
 


### PR DESCRIPTION
**Description**
This PR adds the Snakemake `subclass` value to the template workflow `.dockstore.yml`.  It also fixes a "related" link that was probably intended to point at the notebook `.dockstore.yml` templates.

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7016

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If the PR has any new pages, only **AFTER** the PR is approved by all reviewers, generate a new discourse topic, by running the action at https://github.com/dockstore/dockstore-documentation/actions/workflows/add-discourse-topic.yml. Otherwise we may end up with orphaned topics, which would need manual management.
