### PR TITLE
add faq entry

### DIFF
--- a/docs/advanced-topics/dockstore-cli/dockstore-cli-faq.rst
+++ b/docs/advanced-topics/dockstore-cli/dockstore-cli-faq.rst
@@ -125,7 +125,7 @@ Consider combining this with encryption, a centralized cloud secrets manager, et
 
 ::
 
-    tokenCommmand = cat /home/my-user/dockstoreTokenVault.txt
+    tokenCommand = cat /home/my-user/dockstoreTokenVault.txt
     server-url = https://www.dockstore.org/api
 
 The CLI is failing with Java 8 or 11

--- a/docs/advanced-topics/dockstore-cli/dockstore-cli-faq.rst
+++ b/docs/advanced-topics/dockstore-cli/dockstore-cli-faq.rst
@@ -119,7 +119,7 @@ To prevent these issues from happening, we recommend setting up your Cromwell co
 How do I store my CLI token in a password vault or encrypted file?
 ------------------------------------------------------------------
 
-If for regulatory reasons, you want to kick your security up a notch and store your dockstore token in a password vault or similar,
+If for regulatory reasons, you want to kick your security up a notch and store your Dockstore token in a password vault or similar,
 we have the option of retrieving your Dockstore token using a user-defined command. For example, the following will retrieve the token from a specific text file.
 Consider combining this with encryption, a centralized cloud secrets manager, etc.
 

--- a/docs/advanced-topics/dockstore-cli/dockstore-cli-faq.rst
+++ b/docs/advanced-topics/dockstore-cli/dockstore-cli-faq.rst
@@ -116,11 +116,12 @@ To prevent these issues from happening, we recommend setting up your Cromwell co
 
 :ref:`(back to top) <topCLIFAQ>`
 
-How do I store my CLI token in a password vault or encrypted file
------------------------------------------------------------------
+How do I store my CLI token in a password vault or encrypted file?
+------------------------------------------------------------------
 
 If for regulatory reasons, you want to kick your security up a notch and store your dockstore token in a password vault or similar,
-we have the option of retrieving your Dockstore token using a user-defined command. For example the following will retrieve the token from a different text file:
+we have the option of retrieving your Dockstore token using a user-defined command. For example the following will retrieve the token from a specific text file.
+Consider combining this with encryption, a centralized cloud secrets manager, etc.
 
 ::
 

--- a/docs/advanced-topics/dockstore-cli/dockstore-cli-faq.rst
+++ b/docs/advanced-topics/dockstore-cli/dockstore-cli-faq.rst
@@ -120,12 +120,12 @@ How do I store my CLI token in a password vault or encrypted file?
 ------------------------------------------------------------------
 
 If for regulatory reasons, you want to kick your security up a notch and store your dockstore token in a password vault or similar,
-we have the option of retrieving your Dockstore token using a user-defined command. For example the following will retrieve the token from a specific text file.
+we have the option of retrieving your Dockstore token using a user-defined command. For example, the following will retrieve the token from a specific text file.
 Consider combining this with encryption, a centralized cloud secrets manager, etc.
 
 ::
 
-    token = cat /home/my-user/dockstoreTokenVault.txt
+    tokenCommmand = cat /home/my-user/dockstoreTokenVault.txt
     server-url = https://www.dockstore.org/api
 
 The CLI is failing with Java 8 or 11

--- a/docs/advanced-topics/dockstore-cli/dockstore-cli-faq.rst
+++ b/docs/advanced-topics/dockstore-cli/dockstore-cli-faq.rst
@@ -116,6 +116,17 @@ To prevent these issues from happening, we recommend setting up your Cromwell co
 
 :ref:`(back to top) <topCLIFAQ>`
 
+How do I store my CLI token in a password vault or encrypted file
+-----------------------------------------------------------------
+
+If for regulatory reasons, you want to kick your security up a notch and store your dockstore token in a password vault or similar,
+we have the option of retrieving your Dockstore token using a user-defined command. For example the following will retrieve the token from a different text file:
+
+::
+
+    token = cat /home/my-user/dockstoreTokenVault.txt
+    server-url = https://www.dockstore.org/api
+
 The CLI is failing with Java 8 or 11
 ------------------------------------
 


### PR DESCRIPTION
**Description**
Add an faq entry to the cli faq covering password vault option 
See at https://dockstore--312.org.readthedocs.build/en/312/advanced-topics/dockstore-cli/dockstore-cli-faq.html#how-do-i-store-my-cli-token-in-a-password-vault-or-encrypted-file

**Issue**
https://github.com/dockstore/dockstore-cli/pull/313/files
https://ucsc-cgl.atlassian.net/browse/SEAB-7171

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If the PR has any new pages, only **AFTER** the PR is approved by all reviewers, generate a new discourse topic, by running the action at https://github.com/dockstore/dockstore-documentation/actions/workflows/add-discourse-topic.yml. Otherwise we may end up with orphaned topics, which would need manual management.
