### PR TITLE
update Docker reference and dsl1 to dsl2

### DIFF
--- a/docs/advanced-topics/batch-services.rst
+++ b/docs/advanced-topics/batch-services.rst
@@ -71,7 +71,7 @@ Usage
 
    ::
 
-       consonance run --tool-dockstore-id quay.io/collaboratory/dockstore-tool-bamstats:1.25-6_1.0 --run-descriptor Dockstore.json --flavour <AWS instance-type>
+       consonance run --tool-dockstore-id quay.io/collaboratory/dockstore-tool-bamstats:1.25-7 --run-descriptor Dockstore.json --flavour <AWS instance-type>
 
 .. discourse::
        :topic_identifier: 1545

--- a/docs/advanced-topics/best-practices/wdl-best-practices.rst
+++ b/docs/advanced-topics/best-practices/wdl-best-practices.rst
@@ -38,7 +38,7 @@ This example includes author, email, and description metadata:
         }
 
         runtime {
-            docker: "quay.io/collaboratory/dockstore-tool-bamstats:1.25-6_1.0"
+            docker: "quay.io/collaboratory/dockstore-tool-bamstats:1.25-7"
             memory: mem_gb + "GB"
         }
 

--- a/docs/advanced-topics/legacy/legacy-getting-started-with-cwl.rst
+++ b/docs/advanced-topics/legacy/legacy-getting-started-with-cwl.rst
@@ -307,7 +307,7 @@ the JSON config file:
            --rm \
            --env=TMPDIR=/tmp \
            --env=HOME=/var/spool/cwl \
-           quay.io/collaboratory/dockstore-tool-bamstats:1.25-6_1.0 \
+           quay.io/collaboratory/dockstore-tool-bamstats:1.25-7 \
            bash \
            /usr/local/bin/bamstats \
            4 \

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,7 +85,10 @@ linkcheck_ignore = [
     # sphinx reports
     'https://www.go-fair.org/fair-principles/',
     # sometimes hangs on the cloudflare check
-    'https://bioportal.bioontology.org/ontologies/EDAM'
+    'https://bioportal.bioontology.org/ontologies/EDAM',
+    # medium acting up
+    'https://medium.com/better-programming/how-to-version-your-docker-images-1d5c577ebf54',
+    'https://medium.com/dockstore/dockstore-partners-with-aws-agc-to-make-launching-workflows-quick-and-easy-7213510dabd8'
     ]
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,6 +88,7 @@ linkcheck_ignore = [
     # sometimes hangs on the cloudflare check
     'https://bioportal.bioontology.org/ontologies/EDAM',
     # medium acting up
+    'https://medium.com/dockstore',
     'https://medium.com/better-programming/how-to-version-your-docker-images-1d5c577ebf54',
     'https://medium.com/dockstore/dockstore-partners-with-aws-agc-to-make-launching-workflows-quick-and-easy-7213510dabd8',
     # also biocontainers, wtf

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,6 +74,7 @@ linkcheck_ignore = [
     'https://support.orcid.org/hc/en-us/articles/360006971593-Do-you-have-more-than-one-account',
     # elwazi cert expired, remove when renewed
     'https://elwazi.org/',
+    'https://blog.dnastack.com/introducing-workflows-the-new-standard-in-cloud-bioinformatics-787a59b1d5c6',
     # These links works but the CircleCI client gets denied
     'https://bcc2020.sched.com/event/c4pR/reproducible-analysis-in-the-cloud-with-dockstore-and-terra',
     'https://bcc2020.sched.com/event/c46B/dockstore-fundamentals-introduction-to-docker-and-descriptors-for-reproducible-analysis',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -88,7 +88,9 @@ linkcheck_ignore = [
     'https://bioportal.bioontology.org/ontologies/EDAM',
     # medium acting up
     'https://medium.com/better-programming/how-to-version-your-docker-images-1d5c577ebf54',
-    'https://medium.com/dockstore/dockstore-partners-with-aws-agc-to-make-launching-workflows-quick-and-easy-7213510dabd8'
+    'https://medium.com/dockstore/dockstore-partners-with-aws-agc-to-make-launching-workflows-quick-and-easy-7213510dabd8',
+    # also biocontainers, wtf
+    'https://biocontainers.pro/#/registry'
     ]
 
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -324,7 +324,7 @@ on the underlying host and the temporary directory at
         --rm \
         --env=TMPDIR=/tmp \
         --env=HOME=/var/spool/cwl \
-        quay.io/collaboratory/dockstore-tool-bamstats:1.25-6_1.0 \
+        quay.io/collaboratory/dockstore-tool-bamstats:1.25-7 \
         bash \
         /usr/local/bin/bamstats \
         4 \

--- a/docs/getting-started/getting-started-with-cwl.rst
+++ b/docs/getting-started/getting-started-with-cwl.rst
@@ -302,7 +302,7 @@ the JSON config file:
            --rm \
            --env=TMPDIR=/tmp \
            --env=HOME=/var/spool/cwl \
-           quay.io/collaboratory/dockstore-tool-bamstats:1.25-6_1.0 \
+           quay.io/collaboratory/dockstore-tool-bamstats:1.25-7 \
            bash \
            /usr/local/bin/bamstats \
            4 \

--- a/docs/getting-started/getting-started-with-nextflow.rst
+++ b/docs/getting-started/getting-started-with-nextflow.rst
@@ -115,28 +115,35 @@ Below is the ``main.nf`` file for BAMStats.
 ::
 
     #!/usr/bin/env nextflow
+    nextflow.enable.dsl=2
 
-    bamFile = file(params.bam_input)
+    bamFile = Channel.fromPath(params.bam_input)
+    mem_gb = params.mem_gb
 
     process bamstats {
         input:
-        file bam_input from bamFile
-        val mem_gb from params.mem_gb
+        path(bam_input)
+        val mem_gb
 
         output:
-        file 'bamstats_report.zip'
+        path('bamstats_report.zip')
 
         """
         bash /usr/local/bin/bamstats $mem_gb $bam_input
         """
     }
 
+    workflow {
+        bamstats(bamFile, mem_gb)
+    }
+
+
 First we tell Nextflow that the bam\_input parameter is a file. We do
 this outside of the process.
 
 ::
 
-    bamFile = file(params.bam_input)
+    bamFile = Channel.fromPath(params.bam_input)
 
 Next we will look at the process scope. It is made of the input, output
 and command sections.
@@ -148,8 +155,9 @@ parameter mem\_gb.
 ::
 
     input:
-    file bam_input from bamFile
-    val mem_gb from params.mem_gb
+    path(bam_input)
+    val mem_gb
+
 
 We then define the output of the process as the file
 ``bamstats_report.zip``. Note that we do not do anything with this
@@ -160,7 +168,7 @@ that connection. However, this is not within the scope of this tutorial.
 ::
 
     output:
-    file 'bamstats_report.zip'
+    path('bamstats_report.zip')
 
 The final section is the command section. This section defines what
 command is run by the process. We run the bamstats command line tool and

--- a/docs/getting-started/getting-started-with-nextflow.rst
+++ b/docs/getting-started/getting-started-with-nextflow.rst
@@ -46,7 +46,7 @@ information and settings within scopes, such as manifest and docker.
         mem_gb = '4'
     }
 
-    process.container = 'quay.io/collaboratory/dockstore-tool-bamstats:1.25-6_1.0'
+    process.container = 'quay.io/collaboratory/dockstore-tool-bamstats:1.25-7'
     docker {
         enabled = true
         docker.runOptions = '-u $(id -u):$(id -g)'
@@ -86,7 +86,7 @@ syntax for setting values within a scope.
 
 ::
 
-    process.container = 'quay.io/collaboratory/dockstore-tool-bamstats:1.25-6_1.0'
+    process.container = 'quay.io/collaboratory/dockstore-tool-bamstats:1.25-7'
 
 The last scope of the file is the docker scope. This scope does not
 define the container that we use, instead it defined other Docker
@@ -216,7 +216,7 @@ with the new file.
         mem_gb = '4'
     }
 
-    process.container = 'quay.io/collaboratory/dockstore-tool-bamstats:1.25-6_1.0'
+    process.container = 'quay.io/collaboratory/dockstore-tool-bamstats:1.25-7'
     docker {
         enabled = true
         docker.runOptions = '-u $(id -u):$(id -g)'

--- a/docs/getting-started/getting-started-with-wdl.rst
+++ b/docs/getting-started/getting-started-with-wdl.rst
@@ -75,7 +75,7 @@ repository:
         }
 
         runtime {
-            docker: "quay.io/collaboratory/dockstore-tool-bamstats:1.25-6_1.0"
+            docker: "quay.io/collaboratory/dockstore-tool-bamstats:1.25-7"
             memory: mem_gb + "GB"
         }
     }
@@ -229,7 +229,7 @@ allocated for the task, but we will keep it simple for now.
 ::
 
     runtime {
-        docker: "quay.io/collaboratory/dockstore-tool-bamstats:1.25-6_1.0"
+        docker: "quay.io/collaboratory/dockstore-tool-bamstats:1.25-7"
         memory: mem_gb + "GB"
     }
 

--- a/docs/launch-with/launch.rst
+++ b/docs/launch-with/launch.rst
@@ -49,7 +49,7 @@ follows:
 ::
 
     # make a runtime JSON template and fill in desired inputs, outputs, and other parameters
-    $ dockstore tool convert entry2json --entry quay.io/collaboratory/dockstore-tool-bamstats:1.25-6_1.0 > Dockstore.json
+    $ dockstore tool convert entry2json --entry quay.io/collaboratory/dockstore-tool-bamstats:1.25-7 > Dockstore.json
     $ vim Dockstore.json
     # note that the empty JSON config file has been filled with an input file retrieved via http
     $ cat Dockstore.json
@@ -66,7 +66,7 @@ follows:
       }
     }
     # run it locally with the Dockstore CLI
-    $ dockstore tool launch --entry quay.io/collaboratory/dockstore-tool-bamstats:1.25-6_1.0 --json Dockstore.json
+    $ dockstore tool launch --entry quay.io/collaboratory/dockstore-tool-bamstats:1.25-7 --json Dockstore.json
 
 This information is also provided in the "Launch With" section of every
 tool.

--- a/docs/posters-and-talks.rst
+++ b/docs/posters-and-talks.rst
@@ -34,7 +34,6 @@ CCRC 2019
 Denis Yuen, Jared Baker, Andrew Duncan, & Michelle Brazas. (2019, November). Using Clouds for Big Cancer Data Analysis. Zenodo. https://doi.org/10.5281/zenodo.4527274
 
 - :download:`Slides <https://doi.org/10.5281/zenodo.4527274>`
-- :download:`Workshop <https://bioinformaticsdotca.github.io/Cloud_2019>`
 
 BOSC 2019
 ^^^^^^^^^


### PR DESCRIPTION
**Description**
A Docker reference was incorrectly referring to a Docker image using older schema. Updated to newer one. 
Updated a Nextflow tutorial that fails with newer Nextflow versions 

**Issue**
https://ucsc-cgl.atlassian.net/browse/SEAB-7352

Please make sure that you've checked the following before submitting your pull request. Thanks!

- [x] Ensure that the PR targets the correct branch. Check the milestone or fix version of the ticket.
- [x] If the PR has any new pages, only **AFTER** the PR is approved by all reviewers, generate a new discourse topic, by running the action at https://github.com/dockstore/dockstore-documentation/actions/workflows/add-discourse-topic.yml. Otherwise we may end up with orphaned topics, which would need manual management.
